### PR TITLE
Nested transactions

### DIFF
--- a/src/main/generic/Transaction.js
+++ b/src/main/generic/Transaction.js
@@ -523,7 +523,9 @@ class Transaction {
 
     /**
      * Creates a nested transaction, ensuring read isolation.
-     * For a read isolated transaction, this method has to be called on the main object store.
+     * This makes the current transaction read-only until all sub-transactions have been closed (committed/aborted).
+     * The same semantic for commits applies: Only the first transaction that commits will be applied. Subsequent transactions will be conflicted.
+     * This behaviour has one exception: If all nested transactions are closed, the outer transaction returns to a normal state and new nested transactions can again be created and committed.
      * @returns {Transaction} The transaction object.
      */
     transaction() {

--- a/src/test/generic/Transaction.spec.js
+++ b/src/test/generic/Transaction.spec.js
@@ -129,4 +129,29 @@ describe('Transaction', () => {
             expect(subValue(await index.minValues(JDB.KeyRange.lowerBound(5, true)))).toEqual(new Set(['newValue6']));
         })().then(done, done.fail);
     });
+
+    it('does not allow changing nested transactions', (done) => {
+        (async function () {
+            const tx1 = tx.transaction();
+
+            // Should not be able to remove a key in the outer transaction.
+            try {
+                await tx.remove('key0');
+                done.fail('did not throw when changing outer tx');
+            } catch (e) {
+                // all ok
+            }
+        })().then(done, done.fail);
+    });
+
+    it('does apply nested transactions', (done) => {
+        (async function () {
+            const tx1 = tx.transaction();
+
+            await tx1.put('test', 'foobar');
+            expect(await tx.get('test')).toBeUndefined();
+            expect(await tx1.commit()).toBe(true);
+            expect(await tx.get('test')).toBe('foobar');
+        })().then(done, done.fail);
+    });
 });


### PR DESCRIPTION
Allows to specifically nest transactions.
The outer transactions are read-only until all sub-transactions have been closed (committed/aborted).
The same semantic for commits applies: Only the first transaction that commits will be applied. Subsequent transactions will be conflicted.
This behaviour has one exception: If all nested transactions are closed, the outer transaction returns to a normal state and new nested transactions can again be created and committed.