### PR TITLE
Replace dumb JSON encoding by more sophisticated encoding.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,6 +35,8 @@ const sources = {
     generic: [
         './src/main/generic/utils/ArrayUtils.js',
         './src/main/generic/utils/BTree.js',
+        './src/main/generic/utils/BufferUtils.js',
+        './src/main/generic/utils/JSONUtils.js',
         './src/main/generic/utils/Log.js',
         './src/main/generic/utils/LRUMap.js',
         './src/main/generic/utils/ObjectUtils.js',
@@ -211,7 +213,7 @@ gulp.task('build-node-istanbul', ['build-istanbul'], function () {
 
 gulp.task('test', ['watch'], function () {
     gulp.run(jasmine({
-        files: ['dist/web.js'].concat(sources.test.generic).concat(sources.test.browser)
+        files: ['./src/test/platform/browser/spec.js', 'dist/web.js'].concat(sources.test.generic).concat(sources.test.browser)
     }));
 });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function (config) {
 
         // list of files / patterns to load in the browser
         files: [
+            'src/test/platform/browser/spec.js',
             'dist/web.js',
             'src/test/**/DummyBackend.js',
             'src/test/generic/TestCodec.js',
@@ -114,10 +115,10 @@ module.exports = function (config) {
     for (const version of [57, 58, 59, 60, 61, 62]) sauceLabsConfig('Windows 10', 'chrome', `${version}.0`, 'Chrome', version);
 
     if (process.env.USE_BABEL) {
-        configuration.files[0] = 'dist/web-babel.js';
+        configuration.files[1] = 'dist/web-babel.js';
     }
     if (process.env.USE_ISTANBUL) {
-        configuration.files[0] = 'dist/web-istanbul.js';
+        configuration.files[1] = 'dist/web-istanbul.js';
         configuration.reporters.push('coverage');
         configuration.coverageReporter = {
             reporters: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jungle-db",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "dist/node.js",
   "private": true,
   "scripts": {
@@ -20,6 +20,8 @@
     "node": ">=7.9.0"
   },
   "dependencies": {
+    "atob": "^2.0.3",
+    "btoa": "^1.1.2",
     "fs": "^0.0.1-security",
     "level-sublevel": "^6.6.1",
     "leveldown": "^1.6.0",

--- a/src/loader/nodejs/index.prefix.js
+++ b/src/loader/nodejs/index.prefix.js
@@ -1,5 +1,8 @@
 module.exports = {};
 
+const atob = require('atob');
+const btoa = require('btoa');
+
 const Class = {
     register: clazz => {
         module.exports[clazz.prototype.constructor.name] = clazz;

--- a/src/main/generic/utils/BufferUtils.js
+++ b/src/main/generic/utils/BufferUtils.js
@@ -1,0 +1,19 @@
+class BufferUtils {
+     /**
+     * @param {*} buffer
+     * @return {string}
+     */
+    static toBase64(buffer) {
+        return btoa(String.fromCharCode(...new Uint8Array(buffer)));
+    }
+
+    /**
+     * @param {string} base64
+     * @return {SerialBuffer}
+     */
+    static fromBase64(base64) {
+        return Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+    }
+}
+
+Class.register(BufferUtils);

--- a/src/main/generic/utils/JSONUtils.js
+++ b/src/main/generic/utils/JSONUtils.js
@@ -1,0 +1,42 @@
+class JSONUtils {
+    static stringify(value) {
+        return JSON.stringify(value, JSONUtils.jsonifyType);
+    }
+
+    static parse(value) {
+        return JSON.parse(value, JSONUtils.parseType);
+    }
+
+    static parseType(key, value) {
+        if (value[JSONUtils.TYPE_SYMBOL]) {
+            switch (value[JSONUtils.TYPE_SYMBOL]) {
+                case 'Uint8Array':
+                    return BufferUtils.fromBase64(value[JSONUtils.VALUE_SYMBOL]);
+                case 'Set':
+                    return Set.from(value[JSONUtils.VALUE_SYMBOL]);
+            }
+        }
+        return value;
+    }
+
+    static jsonifyType(key, value) {
+        if (value instanceof Uint8Array) {
+            return JSONUtils.typedObject('Uint8Array', BufferUtils.toBase64(value));
+        }
+        if (value instanceof Set) {
+            return JSONUtils.typedObject('Set', Array.from(value));
+        }
+        return value;
+    }
+
+    static typedObject(type, value) {
+        const obj = {};
+        obj[JSONUtils.TYPE_SYMBOL] = type;
+        obj[JSONUtils.VALUE_SYMBOL] = value;
+        return obj;
+    }
+}
+JSONUtils.TYPE_SYMBOL = '__';
+JSONUtils.VALUE_SYMBOL = 'value';
+
+Class.register(JSONUtils);

--- a/src/main/platform/nodejs/JungleDB.js
+++ b/src/main/platform/nodejs/JungleDB.js
@@ -281,16 +281,8 @@ class JungleDB {
  * @type {{encode: function(val:*):*, decode: function(val:*):*, buffer: boolean, type: string}}
  */
 JungleDB.JSON_ENCODING = {
-    encode: val => JSON.stringify(val, (k, v) => {
-        if (v instanceof Uint8Array) {
-            return Array.from(v);
-        }
-        if (v instanceof Set) {
-            return Array.from(v);
-        }
-        return v;
-    }),
-    decode: JSON.parse,
+    encode: JSONUtils.stringify,
+    decode: JSONUtils.parse,
     buffer: false,
     type: 'json'
 };

--- a/src/test/generic/CombinedTransaction.spec.js
+++ b/src/test/generic/CombinedTransaction.spec.js
@@ -2,10 +2,10 @@ describe('CombinedTransaction', () => {
     let backend1, backend2, objectStore1, objectStore2;
 
     beforeEach((done) => {
-        backend1 = new JDB.InMemoryBackend('');
-        backend2 = new JDB.InMemoryBackend('');
-        objectStore1 = new JDB.ObjectStore(backend1, null);
-        objectStore2 = new JDB.ObjectStore(backend2, null);
+        backend1 = new InMemoryBackend('');
+        backend2 = new InMemoryBackend('');
+        objectStore1 = new ObjectStore(backend1, null);
+        objectStore2 = new ObjectStore(backend2, null);
 
         (async function () {
             // Add 10 objects.
@@ -26,10 +26,10 @@ describe('CombinedTransaction', () => {
             let tx2 = objectStore2.transaction();
             await tx1.remove('key6');
             await tx2.remove('key6');
-            new JDB.CombinedTransaction(tx1, tx2);
+            new CombinedTransaction(tx1, tx2);
 
             expect(await tx1.commit()).toBe(true);
-            expect(await tx2.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(await tx2.state).toBe(Transaction.STATE.COMMITTED);
             expect(await backend1.get('key6')).toBe(undefined);
             expect(await backend2.get('key6')).toBe(undefined);
 
@@ -37,10 +37,10 @@ describe('CombinedTransaction', () => {
             tx2 = objectStore2.transaction();
             await tx1.remove('key7');
             await tx2.remove('key7');
-            new JDB.CombinedTransaction(tx1, tx2);
+            new CombinedTransaction(tx1, tx2);
 
             expect(await tx2.abort()).toBe(true);
-            expect(await tx1.state).toBe(JDB.Transaction.STATE.ABORTED);
+            expect(await tx1.state).toBe(Transaction.STATE.ABORTED);
             expect(await backend1.get('key7')).toBe('value7');
             expect(await backend2.get('key7')).toBe('value7');
         })().then(done, done.fail);
@@ -52,7 +52,7 @@ describe('CombinedTransaction', () => {
             const tx2 = objectStore1.transaction();
             await tx1.remove('key0');
             try {
-                await JDB.JungleDB.commitCombined(tx1, tx2);
+                await JungleDB.commitCombined(tx1, tx2);
                 expect(false).toBe(true);
             } catch (e) {
                 expect(true).toBe(true);
@@ -69,7 +69,7 @@ describe('CombinedTransaction', () => {
             await tx2.remove('key6');
 
             // Commit both (which should immediately update the backend as well).
-            expect(await JDB.JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
             expect(await backend1.get('key6')).toBe(undefined);
             expect(await backend2.get('key6')).toBe(undefined);
         })().then(done, done.fail);
@@ -85,7 +85,7 @@ describe('CombinedTransaction', () => {
             await tx2.remove('key6');
 
             // Commit two of them, which should be successful.
-            expect(await JDB.JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
             // Hence the object store will be updated.
             expect(await objectStore1.get('key6')).toBe(undefined);
             expect(await objectStore2.get('key6')).toBe(undefined);
@@ -117,7 +117,7 @@ describe('CombinedTransaction', () => {
             const tx5 = objectStore2.transaction();
 
             // Commit tx4 and tx1.
-            expect(await JDB.JungleDB.commitCombined(tx1, tx4)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx4)).toBe(true);
             // Hence the object store will be updated.
             expect(await objectStore1.get('key6')).toBe(undefined);
             expect(await objectStore2.get('key6')).toBe(undefined);
@@ -160,7 +160,7 @@ describe('CombinedTransaction', () => {
 
             // Cannot commit combined transactions including a nested transaction.
             try {
-                await JDB.JungleDB.commitCombined(nested, tx2);
+                await JungleDB.commitCombined(nested, tx2);
                 expect(false).toBe(true);
             } catch (e) {
                 expect(true).toBe(true);
@@ -180,7 +180,7 @@ describe('CombinedTransaction', () => {
             expect(await tx3.commit()).toBe(true);
 
             // Commit and fail (not all tx are committable because of conflict).
-            expect(await JDB.JungleDB.commitCombined(tx1, tx2)).toBe(false);
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(false);
             expect(await objectStore1.get('key6')).toBe('value6');
             expect(await objectStore2.get('key6')).toBe('value6');
             expect(await backend1.get('key6')).toBe('value6');
@@ -199,7 +199,7 @@ describe('CombinedTransaction', () => {
             await tx3.remove('key6');
 
             // Commit two transactions.
-            expect(await JDB.JungleDB.commitCombined(tx1, tx3)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx3)).toBe(true);
             // Nothing should be flushed, OS3 should be updated.
             expect(await objectStore1.get('key6')).toBe(undefined);
             expect(await objectStore2.get('key6')).toBe(undefined);
@@ -213,7 +213,7 @@ describe('CombinedTransaction', () => {
             await tx5.put('test', 'successful');
 
             // Next, commit remaining transactions (except tx4) in combination.
-            expect(await JDB.JungleDB.commitCombined(tx4, tx5)).toBe(true);
+            expect(await JungleDB.commitCombined(tx4, tx5)).toBe(true);
             // And everything should be updated, nothing flushed.
             expect(await objectStore1.get('key6')).toBe(undefined);
             expect(await objectStore1.get('test')).toBe('successful');
@@ -256,7 +256,7 @@ describe('CombinedTransaction', () => {
             // Commit both (which should immediately update the backend as well).
             expect(await tx1.get('key6')).toBe('newvalue6');
             expect(await tx2.get('key6')).toBe('newvalue6');
-            expect(await JDB.JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
             expect(await objectStore2.get('key6')).toBe('newvalue6');
             expect(await objectStore1.get('key6')).toBe('newvalue6');
         })().then(done, done.fail);

--- a/src/test/generic/CombinedTransactionPlatform.spec.js
+++ b/src/test/generic/CombinedTransactionPlatform.spec.js
@@ -2,7 +2,7 @@ describe('CombinedTransactionPlatform', () => {
     let jdb, backend1, backend2, objectStore1, objectStore2;
 
     beforeEach((done) => {
-        jdb = new JDB.JungleDB('test', 1);
+        jdb = new JungleDB('test', 1);
         objectStore1 = jdb.createObjectStore('testStore1');
         objectStore2 = jdb.createObjectStore('testStore2');
 
@@ -33,10 +33,10 @@ describe('CombinedTransactionPlatform', () => {
             let tx2 = objectStore2.transaction();
             await tx1.remove('key6');
             await tx2.remove('key6');
-            new JDB.CombinedTransaction(tx1, tx2);
+            new CombinedTransaction(tx1, tx2);
 
             expect(await tx1.commit()).toBe(true);
-            expect(await tx2.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(await tx2.state).toBe(Transaction.STATE.COMMITTED);
             expect(await backend1.get('key6')).toBe(undefined);
             expect(await backend2.get('key6')).toBe(undefined);
 
@@ -44,10 +44,10 @@ describe('CombinedTransactionPlatform', () => {
             tx2 = objectStore2.transaction();
             await tx1.remove('key7');
             await tx2.remove('key7');
-            new JDB.CombinedTransaction(tx1, tx2);
+            new CombinedTransaction(tx1, tx2);
 
             expect(await tx2.abort()).toBe(true);
-            expect(await tx1.state).toBe(JDB.Transaction.STATE.ABORTED);
+            expect(await tx1.state).toBe(Transaction.STATE.ABORTED);
             expect(await backend1.get('key7')).toBe('value7');
             expect(await backend2.get('key7')).toBe('value7');
         })().then(done, done.fail);
@@ -59,7 +59,7 @@ describe('CombinedTransactionPlatform', () => {
             const tx2 = objectStore1.transaction();
             await tx1.remove('key0');
             try {
-                await JDB.JungleDB.commitCombined(tx1, tx2);
+                await JungleDB.commitCombined(tx1, tx2);
                 expect(false).toBe(true);
             } catch (e) {
                 expect(true).toBe(true);
@@ -76,7 +76,7 @@ describe('CombinedTransactionPlatform', () => {
             await tx2.remove('key6');
 
             // Commit both (which should immediately update the backend as well).
-            expect(await JDB.JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
             expect(await backend1.get('key6')).toBe(undefined);
             expect(await backend2.get('key6')).toBe(undefined);
         })().then(done, done.fail);
@@ -92,7 +92,7 @@ describe('CombinedTransactionPlatform', () => {
             await tx2.remove('key6');
 
             // Commit two of them, which should be successful.
-            expect(await JDB.JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
             // Hence the object store will be updated.
             expect(await objectStore1.get('key6')).toBe(undefined);
             expect(await objectStore2.get('key6')).toBe(undefined);
@@ -124,7 +124,7 @@ describe('CombinedTransactionPlatform', () => {
             const tx5 = objectStore2.transaction();
 
             // Commit tx4 and tx1.
-            expect(await JDB.JungleDB.commitCombined(tx1, tx4)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx4)).toBe(true);
             // Hence the object store will be updated.
             expect(await objectStore1.get('key6')).toBe(undefined);
             expect(await objectStore2.get('key6')).toBe(undefined);
@@ -167,7 +167,7 @@ describe('CombinedTransactionPlatform', () => {
 
             // Cannot commit combined transactions including a nested transaction.
             try {
-                await JDB.JungleDB.commitCombined(nested, tx2);
+                await JungleDB.commitCombined(nested, tx2);
                 expect(false).toBe(true);
             } catch (e) {
                 expect(true).toBe(true);
@@ -187,7 +187,7 @@ describe('CombinedTransactionPlatform', () => {
             expect(await tx3.commit()).toBe(true);
 
             // Commit and fail (not all tx are committable because of conflict).
-            expect(await JDB.JungleDB.commitCombined(tx1, tx2)).toBe(false);
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(false);
             expect(await objectStore1.get('key6')).toBe('value6');
             expect(await objectStore2.get('key6')).toBe('value6');
             expect(await backend1.get('key6')).toBe('value6');
@@ -206,7 +206,7 @@ describe('CombinedTransactionPlatform', () => {
             await tx3.remove('key6');
 
             // Commit two transactions.
-            expect(await JDB.JungleDB.commitCombined(tx1, tx3)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx3)).toBe(true);
             // Nothing should be flushed, OS3 should be updated.
             expect(await objectStore1.get('key6')).toBe(undefined);
             expect(await objectStore2.get('key6')).toBe(undefined);
@@ -220,7 +220,7 @@ describe('CombinedTransactionPlatform', () => {
             await tx5.put('test', 'successful');
 
             // Next, commit remaining transactions (except tx4) in combination.
-            expect(await JDB.JungleDB.commitCombined(tx4, tx5)).toBe(true);
+            expect(await JungleDB.commitCombined(tx4, tx5)).toBe(true);
             // And everything should be updated, nothing flushed.
             expect(await objectStore1.get('key6')).toBe(undefined);
             expect(await objectStore1.get('test')).toBe('successful');
@@ -263,7 +263,7 @@ describe('CombinedTransactionPlatform', () => {
             // Commit both (which should immediately update the backend as well).
             expect(await tx1.get('key6')).toBe('newvalue6');
             expect(await tx2.get('key6')).toBe('newvalue6');
-            expect(await JDB.JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
             expect(await objectStore2.get('key6')).toBe('newvalue6');
             expect(await objectStore1.get('key6')).toBe('newvalue6');
         })().then(done, done.fail);

--- a/src/test/generic/DummyBackend.js
+++ b/src/test/generic/DummyBackend.js
@@ -15,7 +15,7 @@ class DummyBackend {
 
         this._codec = codec;
 
-        this._primaryIndex = new JDB.InMemoryIndex(this, undefined, false, true);
+        this._primaryIndex = new InMemoryIndex(this, undefined, false, true);
     }
 
     get committed() {
@@ -87,7 +87,7 @@ class DummyBackend {
      * @returns {Promise.<Array.<*>>}
      */
     async values(query=null) {
-        if (query !== null && query instanceof JDB.Query) {
+        if (query !== null && query instanceof Query) {
             return query.values(this);
         }
         const values = [];
@@ -102,7 +102,7 @@ class DummyBackend {
      * @returns {Promise.<Set.<string>>}
      */
     keys(query=null) {
-        if (query !== null && query instanceof JDB.Query) {
+        if (query !== null && query instanceof Query) {
             return query.keys(this);
         }
         return this._primaryIndex.keys(query);
@@ -278,7 +278,7 @@ class DummyBackend {
      */
     createIndex(indexName, keyPath, multiEntry=false) {
         keyPath = keyPath || indexName;
-        const index = new JDB.InMemoryIndex(this, keyPath, multiEntry);
+        const index = new InMemoryIndex(this, keyPath, multiEntry);
         this._indices.set(indexName, index);
     }
 
@@ -326,4 +326,4 @@ class DummyBackend {
         return 'DummyBackend{}';
     }
 }
-JDB.Class.register(DummyBackend);
+Class.register(DummyBackend);

--- a/src/test/generic/InMemoryBackend.spec.js
+++ b/src/test/generic/InMemoryBackend.spec.js
@@ -6,7 +6,7 @@ describe('InMemoryBackend', () => {
     };
 
     beforeEach((done) => {
-        objectStore = JDB.JungleDB.createVolatileObjectStore();
+        objectStore = JungleDB.createVolatileObjectStore();
 
         (async function () {
             // Add 10 objects.
@@ -24,7 +24,7 @@ describe('InMemoryBackend', () => {
             await tx.remove('key0');
             await tx.put('newKey', 'test');
             expect(await tx.commit()).toBe(true);
-            expect(tx.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx.state).toBe(Transaction.STATE.COMMITTED);
             expect(await objectStore.get('key0')).toBe(undefined);
             expect(await objectStore.get('newKey')).toBe('test');
         })().then(done, done.fail);
@@ -50,7 +50,7 @@ describe('InMemoryBackend', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expect(await tx1.get('key0')).toBe(undefined);
@@ -83,7 +83,7 @@ describe('InMemoryBackend', () => {
 
             // Commit third transaction.
             expect(await tx3.commit()).toBe(true);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx3.state).toBe(Transaction.STATE.COMMITTED);
 
             // Create a fourth transaction, which should be based on tx3.
             const tx4 = objectStore.transaction();
@@ -95,7 +95,7 @@ describe('InMemoryBackend', () => {
             // Abort second transaction and commit empty fourth transaction.
             expect(await tx2.abort()).toBe(true);
             expect(await tx4.commit()).toBe(true);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx4.state).toBe(Transaction.STATE.COMMITTED);
 
             // Now everything should be in the backend.
             expect(await objectStore.get('key0')).toBe('someval');
@@ -126,7 +126,7 @@ describe('InMemoryBackend', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expect(await tx1.get('key0')).toBe(undefined);
@@ -138,7 +138,7 @@ describe('InMemoryBackend', () => {
 
             // Should not be able to commit tx2.
             expect(await tx2.commit()).toBe(false);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.CONFLICTED);
+            expect(tx2.state).toBe(Transaction.STATE.CONFLICTED);
 
             // Abort third transaction.
             expect(await tx3.abort()).toBe(true);
@@ -176,7 +176,7 @@ describe('InMemoryBackend', () => {
                 expect(key).toBe(`key${i}`);
                 --i;
                 return true;
-            }, false, JDB.KeyRange.bound('key1', 'key4'));
+            }, false, KeyRange.bound('key1', 'key4'));
             expect(i).toBe(0);
 
             i = 4;
@@ -184,7 +184,7 @@ describe('InMemoryBackend', () => {
                 expect(key).toBe(`key${i}`);
                 ++i;
                 return i < 5;
-            }, true, JDB.KeyRange.lowerBound('key3', true));
+            }, true, KeyRange.lowerBound('key3', true));
             expect(i).toBe(5);
         })().then(done, done.fail);
     });
@@ -215,7 +215,7 @@ describe('InMemoryBackend', () => {
                 expect(key).toBe(`key${i}`);
                 --i;
                 return true;
-            }, false, JDB.KeyRange.bound('key1', 'key4'));
+            }, false, KeyRange.bound('key1', 'key4'));
             expect(i).toBe(0);
 
             i = 4;
@@ -224,7 +224,7 @@ describe('InMemoryBackend', () => {
                 expect(key).toBe(`key${i}`);
                 ++i;
                 return i < 5;
-            }, true, JDB.KeyRange.lowerBound('key3', true));
+            }, true, KeyRange.lowerBound('key3', true));
             expect(i).toBe(5);
         })().then(done, done.fail);
     });

--- a/src/test/generic/Index.spec.js
+++ b/src/test/generic/Index.spec.js
@@ -18,7 +18,7 @@ describe('Index', () => {
     it('can access longer keypaths', (done) => {
         (async function () {
             // Write something into an object store.
-            let db = new JDB.JungleDB('indexTest', 1);
+            let db = new JungleDB('indexTest', 1);
             let st = db.createObjectStore('testStore');
             st.createIndex('testIndex', 'val');
             st.createIndex('testIndex2', ['a', 'b']);
@@ -28,8 +28,8 @@ describe('Index', () => {
             await st.put('test', {'val': 123, 'a': {'b': 1}});
 
             expect((await st.get('test')).val).toBe(123);
-            expect(await st.keys(JDB.Query.eq('testIndex', 123))).toEqual(new Set(['test']));
-            expect(await st.keys(JDB.Query.eq('testIndex2', 1))).toEqual(new Set(['test']));
+            expect(await st.keys(Query.eq('testIndex', 123))).toEqual(new Set(['test']));
+            expect(await st.keys(Query.eq('testIndex2', 1))).toEqual(new Set(['test']));
 
             await db.destroy();
         })().then(done, done.fail);
@@ -38,7 +38,7 @@ describe('Index', () => {
     it('can handle values not conforming to index', (done) => {
         (async function () {
             // Write something into an object store.
-            let db = new JDB.JungleDB('indexTest', 1);
+            let db = new JungleDB('indexTest', 1);
             let st = db.createObjectStore('testStore');
             st.createIndex('depth', ['treeInfo', 'depth']);
 
@@ -66,8 +66,8 @@ describe('Index', () => {
             // Retrieve values at specific depth.
             expect(await st.get('head')).toBe(`${49*10+4}`);
 
-            const atDepth5 = await st.values(JDB.Query.eq('depth', 5));
-            const atDepth15 = await st.values(JDB.Query.eq('depth', 15));
+            const atDepth5 = await st.values(Query.eq('depth', 5));
+            const atDepth15 = await st.values(Query.eq('depth', 15));
 
             let actualJs = new Set();
             for (const obj of atDepth5) {
@@ -84,7 +84,7 @@ describe('Index', () => {
             expect(actualJs).toEqual(expectedJs);
 
             // Retrieve values in depth range for given j.
-            const range = await st.values(JDB.Query.within('depth', 5, 15));
+            const range = await st.values(Query.within('depth', 5, 15));
             const expectedIs = Set.from([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
             for (let j=0; j<5; ++j) {
                 const actualIs = new Set();

--- a/src/test/generic/JungleDB.spec.js
+++ b/src/test/generic/JungleDB.spec.js
@@ -3,7 +3,7 @@ describe('JungleDB', () => {
     it('can connect', (done) => {
         let called = false;
 
-        const db = new JDB.JungleDB('test', 1, () => {
+        const db = new JungleDB('test', 1, () => {
             called = true;
         });
 
@@ -17,7 +17,7 @@ describe('JungleDB', () => {
     it('can reconnect to a database', (done) => {
         let called = false;
         (async function () {
-            let db = new JDB.JungleDB('test', 1, () => {
+            let db = new JungleDB('test', 1, () => {
                 called = true;
             });
             await db.connect();
@@ -26,7 +26,7 @@ describe('JungleDB', () => {
             await db.close();
 
             called = false;
-            db = new JDB.JungleDB('test', 1, () => {
+            db = new JungleDB('test', 1, () => {
                 called = true;
             });
             await db.connect();
@@ -35,7 +35,7 @@ describe('JungleDB', () => {
             await db.close();
 
             called = false;
-            db = new JDB.JungleDB('test', 2, () => {
+            db = new JungleDB('test', 2, () => {
                 called = true;
             });
             await db.connect();
@@ -48,27 +48,27 @@ describe('JungleDB', () => {
     it('can create and delete object stores', (done) => {
         (async function () {
             // Write something into an object store.
-            let db = new JDB.JungleDB('test', 1);
+            let db = new JungleDB('test', 1);
             let st = db.createObjectStore('testStore');
             await db.connect();
             await st.put('test', 'succeeded');
             await db.close();
 
             // And test whether it is still there.
-            db = new JDB.JungleDB('test', 1);
+            db = new JungleDB('test', 1);
             st = db.createObjectStore('testStore');
             await db.connect();
             expect(await st.get('test')).toBe('succeeded');
             await db.close();
 
             // Delete it now.
-            db = new JDB.JungleDB('test', 2);
+            db = new JungleDB('test', 2);
             await db.deleteObjectStore('testStore');
             await db.connect();
             await db.close();
 
             // And check that is has been deleted.
-            db = new JDB.JungleDB('test', 3);
+            db = new JungleDB('test', 3);
             st = db.createObjectStore('testStore');
             await db.connect();
             expect(await st.get('test')).toBe(undefined);

--- a/src/test/generic/ObjectStore.spec.js
+++ b/src/test/generic/ObjectStore.spec.js
@@ -8,7 +8,7 @@ describe('ObjectStore', () => {
     beforeEach((done) => {
         backend = new DummyBackend();
 
-        objectStore = new JDB.ObjectStore(backend, backend);
+        objectStore = new ObjectStore(backend, backend);
 
         (async function () {
             // Add 10 objects.
@@ -26,7 +26,7 @@ describe('ObjectStore', () => {
             await tx.remove('key0');
             await tx.put('newKey', 'test');
             expect(await tx.commit()).toBe(true);
-            expect(tx.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx.state).toBe(Transaction.STATE.COMMITTED);
             expect(await objectStore.get('key0')).toBe(undefined);
             expect(await objectStore.get('newKey')).toBe('test');
         })().then(done, done.fail);
@@ -52,7 +52,7 @@ describe('ObjectStore', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expect(await tx1.get('key0')).toBe(undefined);
@@ -88,7 +88,7 @@ describe('ObjectStore', () => {
 
             // Commit third transaction.
             expect(await tx3.commit()).toBe(true);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx3.state).toBe(Transaction.STATE.COMMITTED);
 
             // Create a fourth transaction, which should be based on tx3.
             const tx4 = objectStore.transaction();
@@ -104,7 +104,7 @@ describe('ObjectStore', () => {
             // Abort second transaction and commit empty fourth transaction.
             expect(await tx2.abort()).toBe(true);
             expect(await tx4.commit()).toBe(true);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx4.state).toBe(Transaction.STATE.COMMITTED);
 
             // Now everything should be in the backend.
             expect(await backend.get('key0')).toBe('someval');
@@ -139,7 +139,7 @@ describe('ObjectStore', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expect(await tx1.get('key0')).toBe(undefined);
@@ -153,7 +153,7 @@ describe('ObjectStore', () => {
 
             // Should not be able to commit tx2.
             expect(await tx2.commit()).toBe(false);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.CONFLICTED);
+            expect(tx2.state).toBe(Transaction.STATE.CONFLICTED);
 
             // tx1 might be flushed by now. No more transactions possible on top of it.
             try {
@@ -192,16 +192,16 @@ describe('ObjectStore', () => {
         (async function () {
             // Create two transactions on the main state.
             const tx1 = objectStore.transaction();
-            expect(tx1.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx1.state).toBe(Transaction.STATE.OPEN);
             const tx2 = tx1.transaction();
-            expect(tx1.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx1.state).toBe(Transaction.STATE.NESTED);
+            expect(tx2.state).toBe(Transaction.STATE.OPEN);
             const tx3 = tx2.transaction();
-            expect(tx2.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx2.state).toBe(Transaction.STATE.NESTED);
+            expect(tx3.state).toBe(Transaction.STATE.OPEN);
             const tx4 = tx2.transaction();
-            expect(tx2.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx2.state).toBe(Transaction.STATE.NESTED);
+            expect(tx4.state).toBe(Transaction.STATE.OPEN);
 
             // Should not be able to commit.
             try {
@@ -219,34 +219,34 @@ describe('ObjectStore', () => {
                 // all ok
             }
 
-            expect(tx1.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.OPEN);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx1.state).toBe(Transaction.STATE.NESTED);
+            expect(tx2.state).toBe(Transaction.STATE.NESTED);
+            expect(tx3.state).toBe(Transaction.STATE.OPEN);
+            expect(tx4.state).toBe(Transaction.STATE.OPEN);
 
             expect(await tx3.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.COMMITTED);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx1.state).toBe(Transaction.STATE.NESTED);
+            expect(tx2.state).toBe(Transaction.STATE.NESTED);
+            expect(tx3.state).toBe(Transaction.STATE.COMMITTED);
+            expect(tx4.state).toBe(Transaction.STATE.OPEN);
 
             expect(await tx4.commit()).toBe(false);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.OPEN);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.COMMITTED);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.CONFLICTED);
+            expect(tx1.state).toBe(Transaction.STATE.NESTED);
+            expect(tx2.state).toBe(Transaction.STATE.OPEN);
+            expect(tx3.state).toBe(Transaction.STATE.COMMITTED);
+            expect(tx4.state).toBe(Transaction.STATE.CONFLICTED);
 
             expect(await tx2.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.OPEN);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.COMMITTED);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.COMMITTED);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.CONFLICTED);
+            expect(tx1.state).toBe(Transaction.STATE.OPEN);
+            expect(tx2.state).toBe(Transaction.STATE.COMMITTED);
+            expect(tx3.state).toBe(Transaction.STATE.COMMITTED);
+            expect(tx4.state).toBe(Transaction.STATE.CONFLICTED);
 
             expect(await tx1.abort()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.ABORTED);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.COMMITTED);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.COMMITTED);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.CONFLICTED);
+            expect(tx1.state).toBe(Transaction.STATE.ABORTED);
+            expect(tx2.state).toBe(Transaction.STATE.COMMITTED);
+            expect(tx3.state).toBe(Transaction.STATE.COMMITTED);
+            expect(tx4.state).toBe(Transaction.STATE.CONFLICTED);
         })().then(done, done.fail);
     });
 
@@ -254,22 +254,22 @@ describe('ObjectStore', () => {
         (async function () {
             // Create two transactions on the main state.
             const tx1 = objectStore.transaction();
-            expect(tx1.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx1.state).toBe(Transaction.STATE.OPEN);
             const tx2 = tx1.transaction();
-            expect(tx1.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx1.state).toBe(Transaction.STATE.NESTED);
+            expect(tx2.state).toBe(Transaction.STATE.OPEN);
             const tx3 = tx2.transaction();
-            expect(tx2.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx2.state).toBe(Transaction.STATE.NESTED);
+            expect(tx3.state).toBe(Transaction.STATE.OPEN);
             const tx4 = tx2.transaction();
-            expect(tx2.state).toBe(JDB.Transaction.STATE.NESTED);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.OPEN);
+            expect(tx2.state).toBe(Transaction.STATE.NESTED);
+            expect(tx4.state).toBe(Transaction.STATE.OPEN);
 
             await tx1.abort();
-            expect(tx1.state).toBe(JDB.Transaction.STATE.ABORTED);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.ABORTED);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.ABORTED);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.ABORTED);
+            expect(tx1.state).toBe(Transaction.STATE.ABORTED);
+            expect(tx2.state).toBe(Transaction.STATE.ABORTED);
+            expect(tx3.state).toBe(Transaction.STATE.ABORTED);
+            expect(tx4.state).toBe(Transaction.STATE.ABORTED);
         })().then(done, done.fail);
     });
 
@@ -277,7 +277,7 @@ describe('ObjectStore', () => {
         (async function () {
             let txC;
 
-            for (let i=0; i<JDB.ObjectStore.MAX_STACK_SIZE; ++i) {
+            for (let i=0; i<ObjectStore.MAX_STACK_SIZE; ++i) {
                 objectStore.transaction();
                 txC = objectStore.transaction();
                 await txC.commit();

--- a/src/test/generic/ObjectStoreBinaryCodec.spec.js
+++ b/src/test/generic/ObjectStoreBinaryCodec.spec.js
@@ -30,7 +30,7 @@ describe('BinaryCodec', () => {
     beforeEach((done) => {
         backend = new DummyBackend(BinaryCodec.instance);
 
-        objectStore = new JDB.ObjectStore(backend, backend);
+        objectStore = new ObjectStore(backend, backend);
 
         (async function () {
             // Add 10 objects.
@@ -48,7 +48,7 @@ describe('BinaryCodec', () => {
             await tx.remove('key0');
             await tx.put('newKey', objfy('newKey', 'test'));
             expect(await tx.commit()).toBe(true);
-            expect(tx.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx.state).toBe(Transaction.STATE.COMMITTED);
             expectvaluefy(await objectStore.get('key0')).toBe(undefined);
             expectvaluefy(await objectStore.get('newKey')).toBe('test');
         })().then(done, done.fail);
@@ -74,7 +74,7 @@ describe('BinaryCodec', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expectvaluefy(await tx1.get('key0')).toBe(undefined);
@@ -110,7 +110,7 @@ describe('BinaryCodec', () => {
 
             // Commit third transaction.
             expect(await tx3.commit()).toBe(true);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx3.state).toBe(Transaction.STATE.COMMITTED);
 
             // Create a fourth transaction, which should be based on tx3.
             const tx4 = objectStore.transaction();
@@ -126,7 +126,7 @@ describe('BinaryCodec', () => {
             // Abort second transaction and commit empty fourth transaction.
             expect(await tx2.abort()).toBe(true);
             expect(await tx4.commit()).toBe(true);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx4.state).toBe(Transaction.STATE.COMMITTED);
 
             // Now everything should be in the backend.
             expectvaluefy(await backend.get('key0')).toBe('someval');
@@ -161,7 +161,7 @@ describe('BinaryCodec', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expect(await tx1.get('key0')).toBe(undefined);
@@ -175,7 +175,7 @@ describe('BinaryCodec', () => {
 
             // Should not be able to commit tx2.
             expect(await tx2.commit()).toBe(false);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.CONFLICTED);
+            expect(tx2.state).toBe(Transaction.STATE.CONFLICTED);
 
             // tx1 might be flushed by now. No more transactions possible on top of it.
             try {

--- a/src/test/generic/ObjectStoreTestCodec.spec.js
+++ b/src/test/generic/ObjectStoreTestCodec.spec.js
@@ -30,7 +30,7 @@ describe('TestCodec', () => {
     beforeEach((done) => {
         backend = new DummyBackend(TestCodec.instance);
 
-        objectStore = new JDB.ObjectStore(backend, backend);
+        objectStore = new ObjectStore(backend, backend);
 
         (async function () {
             // Add 10 objects.
@@ -48,7 +48,7 @@ describe('TestCodec', () => {
             await tx.remove('key0');
             await tx.put('newKey', objfy('newKey', 'test'));
             expect(await tx.commit()).toBe(true);
-            expect(tx.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx.state).toBe(Transaction.STATE.COMMITTED);
             expectvaluefy(await objectStore.get('key0')).toBe(undefined);
             expectvaluefy(await objectStore.get('newKey')).toBe('test');
         })().then(done, done.fail);
@@ -74,7 +74,7 @@ describe('TestCodec', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expectvaluefy(await tx1.get('key0')).toBe(undefined);
@@ -110,7 +110,7 @@ describe('TestCodec', () => {
 
             // Commit third transaction.
             expect(await tx3.commit()).toBe(true);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx3.state).toBe(Transaction.STATE.COMMITTED);
 
             // Create a fourth transaction, which should be based on tx3.
             const tx4 = objectStore.transaction();
@@ -126,7 +126,7 @@ describe('TestCodec', () => {
             // Abort second transaction and commit empty fourth transaction.
             expect(await tx2.abort()).toBe(true);
             expect(await tx4.commit()).toBe(true);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx4.state).toBe(Transaction.STATE.COMMITTED);
 
             // Now everything should be in the backend.
             expectvaluefy(await backend.get('key0')).toBe('someval');
@@ -161,7 +161,7 @@ describe('TestCodec', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expect(await tx1.get('key0')).toBe(undefined);
@@ -175,7 +175,7 @@ describe('TestCodec', () => {
 
             // Should not be able to commit tx2.
             expect(await tx2.commit()).toBe(false);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.CONFLICTED);
+            expect(tx2.state).toBe(Transaction.STATE.CONFLICTED);
 
             // tx1 might be flushed by now. No more transactions possible on top of it.
             try {

--- a/src/test/generic/PlatformSpecificBackend.spec.js
+++ b/src/test/generic/PlatformSpecificBackend.spec.js
@@ -6,7 +6,7 @@ describe('PlatformSpecificBackend', () => {
     };
 
     beforeEach((done) => {
-        db = new JDB.JungleDB('test', 1);
+        db = new JungleDB('test', 1);
         objectStore = db.createObjectStore('testStore');
 
         allKeys = new Set();
@@ -35,7 +35,7 @@ describe('PlatformSpecificBackend', () => {
             await tx.remove('key0');
             await tx.put('newKey', 'test');
             expect(await tx.commit()).toBe(true);
-            expect(tx.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx.state).toBe(Transaction.STATE.COMMITTED);
             expect(await objectStore.get('key0')).toBe(undefined);
             expect(await objectStore.get('newKey')).toBe('test');
         })().then(done, done.fail);
@@ -61,7 +61,7 @@ describe('PlatformSpecificBackend', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expect(await tx1.get('key0')).toBe(undefined);
@@ -94,7 +94,7 @@ describe('PlatformSpecificBackend', () => {
 
             // Commit third transaction.
             expect(await tx3.commit()).toBe(true);
-            expect(tx3.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx3.state).toBe(Transaction.STATE.COMMITTED);
 
             // Create a fourth transaction, which should be based on tx3.
             const tx4 = objectStore.transaction();
@@ -106,7 +106,7 @@ describe('PlatformSpecificBackend', () => {
             // Abort second transaction and commit empty fourth transaction.
             expect(await tx2.abort()).toBe(true);
             expect(await tx4.commit()).toBe(true);
-            expect(tx4.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx4.state).toBe(Transaction.STATE.COMMITTED);
 
             // Now everything should be in the backend.
             expect(await objectStore.get('key0')).toBe('someval');
@@ -137,7 +137,7 @@ describe('PlatformSpecificBackend', () => {
 
             // Commit one transaction.
             expect(await tx1.commit()).toBe(true);
-            expect(tx1.state).toBe(JDB.Transaction.STATE.COMMITTED);
+            expect(tx1.state).toBe(Transaction.STATE.COMMITTED);
 
             // Still ensure read isolation.
             expect(await tx1.get('key0')).toBe(undefined);
@@ -149,7 +149,7 @@ describe('PlatformSpecificBackend', () => {
 
             // Should not be able to commit tx2.
             expect(await tx2.commit()).toBe(false);
-            expect(tx2.state).toBe(JDB.Transaction.STATE.CONFLICTED);
+            expect(tx2.state).toBe(Transaction.STATE.CONFLICTED);
 
             // Abort third transaction.
             expect(await tx3.abort()).toBe(true);
@@ -168,9 +168,9 @@ describe('PlatformSpecificBackend', () => {
         (async function () {
             // Ordering on strings might not be as expected!
             expect(await objectStore.keys()).toEqual(allKeys);
-            expect(await objectStore.keys(JDB.KeyRange.upperBound('key5'))).toEqual(new Set(['key0', 'key1', 'key2', 'key3', 'key4', 'key5']));
-            expect(await objectStore.keys(JDB.KeyRange.lowerBound('key1', true))).toEqual(allKeys.difference(['key0', 'key1']));
-            expect(await objectStore.keys(JDB.KeyRange.lowerBound('key5', true))).toEqual(new Set(['key6', 'key7', 'key8', 'key9']));
+            expect(await objectStore.keys(KeyRange.upperBound('key5'))).toEqual(new Set(['key0', 'key1', 'key2', 'key3', 'key4', 'key5']));
+            expect(await objectStore.keys(KeyRange.lowerBound('key1', true))).toEqual(allKeys.difference(['key0', 'key1']));
+            expect(await objectStore.keys(KeyRange.lowerBound('key5', true))).toEqual(new Set(['key6', 'key7', 'key8', 'key9']));
         })().then(done, done.fail);
     });
 
@@ -197,7 +197,7 @@ describe('PlatformSpecificBackend', () => {
                 expect(key).toBe(`key${i}`);
                 --i;
                 return true;
-            }, false, JDB.KeyRange.bound('key1', 'key4'));
+            }, false, KeyRange.bound('key1', 'key4'));
             expect(i).toBe(0);
 
             i = 4;
@@ -205,7 +205,7 @@ describe('PlatformSpecificBackend', () => {
                 expect(key).toBe(`key${i}`);
                 ++i;
                 return i < 5;
-            }, true, JDB.KeyRange.lowerBound('key3', true));
+            }, true, KeyRange.lowerBound('key3', true));
             expect(i).toBe(5);
         })().then(done, done.fail);
     });
@@ -236,7 +236,7 @@ describe('PlatformSpecificBackend', () => {
                 expect(key).toBe(`key${i}`);
                 --i;
                 return true;
-            }, false, JDB.KeyRange.bound('key1', 'key4'));
+            }, false, KeyRange.bound('key1', 'key4'));
             expect(i).toBe(0);
 
             i = 4;
@@ -245,7 +245,7 @@ describe('PlatformSpecificBackend', () => {
                 expect(key).toBe(`key${i}`);
                 ++i;
                 return i < 5;
-            }, true, JDB.KeyRange.lowerBound('key3', true));
+            }, true, KeyRange.lowerBound('key3', true));
             expect(i).toBe(5);
         })().then(done, done.fail);
     });

--- a/src/test/generic/Query.spec.js
+++ b/src/test/generic/Query.spec.js
@@ -27,50 +27,50 @@ describe('Query', () => {
 
     it('can process single entry range queries', (done) => {
         (async function () {
-            expect(await backend.keys(JDB.Query.eq('test', 0))).toEqual(new Set(['key0']));
-            expect(await backend.keys(JDB.Query.le('test', 1))).toEqual(new Set(['key0', 'key1']));
-            expect(await backend.keys(JDB.Query.lt('test', 1))).toEqual(new Set(['key0']));
-            expect(await backend.keys(JDB.Query.ge('test', 8))).toEqual(new Set(['key8', 'key9']));
-            expect(await backend.keys(JDB.Query.gt('test', 7))).toEqual(new Set(['key8', 'key9']));
-            expect(await backend.keys(JDB.Query.between('test', 1, 3))).toEqual(new Set(['key2']));
-            expect(await backend.keys(JDB.Query.within('test', 1, 3))).toEqual(new Set(['key1', 'key2', 'key3']));
+            expect(await backend.keys(Query.eq('test', 0))).toEqual(new Set(['key0']));
+            expect(await backend.keys(Query.le('test', 1))).toEqual(new Set(['key0', 'key1']));
+            expect(await backend.keys(Query.lt('test', 1))).toEqual(new Set(['key0']));
+            expect(await backend.keys(Query.ge('test', 8))).toEqual(new Set(['key8', 'key9']));
+            expect(await backend.keys(Query.gt('test', 7))).toEqual(new Set(['key8', 'key9']));
+            expect(await backend.keys(Query.between('test', 1, 3))).toEqual(new Set(['key2']));
+            expect(await backend.keys(Query.within('test', 1, 3))).toEqual(new Set(['key1', 'key2', 'key3']));
         })().then(done, done.fail);
     });
 
     it('can process single entry min/max queries', (done) => {
         (async function () {
-            expect(await backend.keys(JDB.Query.max('test'))).toEqual(new Set(['key9']));
-            expect(await backend.keys(JDB.Query.min('test'))).toEqual(new Set(['key0']));
+            expect(await backend.keys(Query.max('test'))).toEqual(new Set(['key9']));
+            expect(await backend.keys(Query.min('test'))).toEqual(new Set(['key0']));
         })().then(done, done.fail);
     });
 
     it('can process single entry combined queries', (done) => {
         (async function () {
-            expect(await backend.keys(JDB.Query.and(JDB.Query.ge('test', 3), JDB.Query.lt('test', 5)))).toEqual(new Set(['key3', 'key4']));
-            expect(await backend.keys(JDB.Query.or(JDB.Query.within('test', 1, 2), JDB.Query.ge('test', 7)))).toEqual(new Set(['key1', 'key2', 'key7', 'key8', 'key9']));
-            expect(await backend.keys(JDB.Query.or(JDB.Query.within('test', 1, 2), JDB.Query.and(JDB.Query.ge('test', 7), JDB.Query.lt('test', 9))))).toEqual(new Set(['key1', 'key2', 'key7', 'key8']));
+            expect(await backend.keys(Query.and(Query.ge('test', 3), Query.lt('test', 5)))).toEqual(new Set(['key3', 'key4']));
+            expect(await backend.keys(Query.or(Query.within('test', 1, 2), Query.ge('test', 7)))).toEqual(new Set(['key1', 'key2', 'key7', 'key8', 'key9']));
+            expect(await backend.keys(Query.or(Query.within('test', 1, 2), Query.and(Query.ge('test', 7), Query.lt('test', 9))))).toEqual(new Set(['key1', 'key2', 'key7', 'key8']));
         })().then(done, done.fail);
     });
 
     it('can process multi entry range queries', (done) => {
         (async function () {
-            expect(await backend.keys(JDB.Query.eq('multi', 3))).toEqual(new Set(['key3']));
-            expect(await backend.keys(JDB.Query.eq('multi', 1))).toEqual(new Set(['key1', 'key3', 'key5', 'key7', 'key9']));
+            expect(await backend.keys(Query.eq('multi', 3))).toEqual(new Set(['key3']));
+            expect(await backend.keys(Query.eq('multi', 1))).toEqual(new Set(['key1', 'key3', 'key5', 'key7', 'key9']));
         })().then(done, done.fail);
     });
 
     it('can process multi entry min/max queries', (done) => {
         (async function () {
-            expect(await backend.keys(JDB.Query.min('multi'))).toEqual(new Set(['key0', 'key2', 'key4', 'key6', 'key8']));
-            expect(await backend.keys(JDB.Query.max('multi'))).toEqual(new Set(['key9']));
+            expect(await backend.keys(Query.min('multi'))).toEqual(new Set(['key0', 'key2', 'key4', 'key6', 'key8']));
+            expect(await backend.keys(Query.max('multi'))).toEqual(new Set(['key9']));
         })().then(done, done.fail);
     });
 
     it('can process queries over multiple indices', (done) => {
         (async function () {
-            expect(await backend.keys(JDB.Query.or(JDB.Query.eq('test', 2), JDB.Query.eq('multi', 1)))).toEqual(new Set(['key1', 'key2', 'key3', 'key5', 'key7', 'key9']));
-            expect(await backend.keys(JDB.Query.and(JDB.Query.max('test'), JDB.Query.eq('multi', 1)))).toEqual(new Set(['key9']));
-            expect(await backend.keys(JDB.Query.and(JDB.Query.min('test'), JDB.Query.min('multi')))).toEqual(new Set(['key0']));
+            expect(await backend.keys(Query.or(Query.eq('test', 2), Query.eq('multi', 1)))).toEqual(new Set(['key1', 'key2', 'key3', 'key5', 'key7', 'key9']));
+            expect(await backend.keys(Query.and(Query.max('test'), Query.eq('multi', 1)))).toEqual(new Set(['key9']));
+            expect(await backend.keys(Query.and(Query.min('test'), Query.min('multi')))).toEqual(new Set(['key0']));
         })().then(done, done.fail);
     });
 });

--- a/src/test/generic/Snapshot.spec.js
+++ b/src/test/generic/Snapshot.spec.js
@@ -9,7 +9,7 @@ describe('Snapshot', () => {
     };
 
     beforeEach((done) => {
-        db = new JDB.JungleDB('test', 1);
+        db = new JungleDB('test', 1);
         objectStore = db.createObjectStore('testStore');
         objectStore.createIndex('test', ['a', 'b'], true);
 
@@ -230,10 +230,10 @@ describe('Snapshot', () => {
             await objectStore.remove('newTest1');
 
             const index = snap.index('test');
-            expect(await index.keys(JDB.KeyRange.only(123))).toEqual(new Set(['newTest', 'newTest1']));
-            expect(await index.keys(JDB.KeyRange.lowerBound(123, true))).toEqual(new Set(['newTest2']));
+            expect(await index.keys(KeyRange.only(123))).toEqual(new Set(['newTest', 'newTest1']));
+            expect(await index.keys(KeyRange.lowerBound(123, true))).toEqual(new Set(['newTest2']));
 
-            const values = await snap.values(JDB.Query.eq('test', 123));
+            const values = await snap.values(Query.eq('test', 123));
             const expectedKeys = new Set(['newTest', 'newTest1']);
             for (const value of values) {
                 expect(expectedKeys.delete(value['key'])).toBe(true);

--- a/src/test/generic/TestCodec.js
+++ b/src/test/generic/TestCodec.js
@@ -40,7 +40,7 @@ class TestCodec {
      * @type {{encode: function(val:*):*, decode: function(val:*):*, buffer: boolean, type: string}|void}
      */
     get valueEncoding() {
-        return JDB.JungleDB.JSON_ENCODING;
+        return JungleDB.JSON_ENCODING;
     }
 }
-JDB.Class.register(TestCodec);
+Class.register(TestCodec);

--- a/src/test/generic/Transaction.spec.js
+++ b/src/test/generic/Transaction.spec.js
@@ -22,7 +22,7 @@ describe('Transaction', () => {
 
         (async function () {
             backend.createIndex('i');
-            tx = new JDB.Transaction(backend, backend, false);
+            tx = new Transaction(backend, backend, false);
 
             // Add 10 objects.
             for (let i=0; i<10; ++i) {
@@ -49,9 +49,9 @@ describe('Transaction', () => {
         (async function () {
             // Ordering on strings might not be as expected!
             expect(await tx.keys()).toEqual(allKeys);
-            expect(await tx.keys(JDB.KeyRange.upperBound('key5'))).toEqual(new Set(['key1', 'key2', 'key3', 'key4', 'key5', 'key10', 'key11', 'key12', 'key13', 'key14']));
-            expect(await tx.keys(JDB.KeyRange.lowerBound('key1', true))).toEqual(allKeys.difference(['key1']));
-            expect(await tx.keys(JDB.KeyRange.lowerBound('key5', true))).toEqual(new Set(['key6', 'key7', 'key8', 'key9']));
+            expect(await tx.keys(KeyRange.upperBound('key5'))).toEqual(new Set(['key1', 'key2', 'key3', 'key4', 'key5', 'key10', 'key11', 'key12', 'key13', 'key14']));
+            expect(await tx.keys(KeyRange.lowerBound('key1', true))).toEqual(allKeys.difference(['key1']));
+            expect(await tx.keys(KeyRange.lowerBound('key5', true))).toEqual(new Set(['key6', 'key7', 'key8', 'key9']));
 
             expect(subValue(await tx.values())).toEqual(allValues);
         })().then(done, done.fail);
@@ -61,15 +61,15 @@ describe('Transaction', () => {
         (async function () {
             expect(await tx.minKey()).toBe('key1');
             expect(await tx.maxKey()).toBe('key9');
-            expect(await tx.minKey(JDB.KeyRange.upperBound('key5'))).toBe('key1');
-            expect(await tx.minKey(JDB.KeyRange.lowerBound('key1', true))).toBe('key10');
-            expect(await tx.minKey(JDB.KeyRange.lowerBound('key5', true))).toBe('key6');
+            expect(await tx.minKey(KeyRange.upperBound('key5'))).toBe('key1');
+            expect(await tx.minKey(KeyRange.lowerBound('key1', true))).toBe('key10');
+            expect(await tx.minKey(KeyRange.lowerBound('key5', true))).toBe('key6');
 
             expect((await tx.minValue()).sub).toBe('value1');
             expect((await tx.maxValue()).sub).toBe('newValue9');
-            expect((await tx.minValue(JDB.KeyRange.upperBound('key5'))).sub).toBe('value1');
-            expect((await tx.minValue(JDB.KeyRange.lowerBound('key1', true))).sub).toBe('newValue10');
-            expect((await tx.minValue(JDB.KeyRange.lowerBound('key5', true))).sub).toBe('newValue6');
+            expect((await tx.minValue(KeyRange.upperBound('key5'))).sub).toBe('value1');
+            expect((await tx.minValue(KeyRange.lowerBound('key1', true))).sub).toBe('newValue10');
+            expect((await tx.minValue(KeyRange.lowerBound('key5', true))).sub).toBe('newValue6');
         })().then(done, done.fail);
     });
 
@@ -122,15 +122,15 @@ describe('Transaction', () => {
             const index = tx.index('i');
             expect(await index.minKeys()).toEqual(new Set(['key1']));
             expect(await index.maxKeys()).toEqual(new Set(['key14']));
-            expect(await index.minKeys(JDB.KeyRange.upperBound(5))).toEqual(new Set(['key1']));
-            expect(await index.minKeys(JDB.KeyRange.lowerBound(1, true))).toEqual(new Set(['key2']));
-            expect(await index.minKeys(JDB.KeyRange.lowerBound(5, true))).toEqual(new Set(['key6']));
+            expect(await index.minKeys(KeyRange.upperBound(5))).toEqual(new Set(['key1']));
+            expect(await index.minKeys(KeyRange.lowerBound(1, true))).toEqual(new Set(['key2']));
+            expect(await index.minKeys(KeyRange.lowerBound(5, true))).toEqual(new Set(['key6']));
 
             expect(subValue(await index.minValues())).toEqual(new Set(['value1']));
             expect(subValue(await index.maxValues())).toEqual(new Set(['newValue14']));
-            expect(subValue(await index.minValues(JDB.KeyRange.upperBound(5)))).toEqual(new Set(['value1']));
-            expect(subValue(await index.minValues(JDB.KeyRange.lowerBound(1, true)))).toEqual(new Set(['value2']));
-            expect(subValue(await index.minValues(JDB.KeyRange.lowerBound(5, true)))).toEqual(new Set(['newValue6']));
+            expect(subValue(await index.minValues(KeyRange.upperBound(5)))).toEqual(new Set(['value1']));
+            expect(subValue(await index.minValues(KeyRange.lowerBound(1, true)))).toEqual(new Set(['value2']));
+            expect(subValue(await index.minValues(KeyRange.lowerBound(5, true)))).toEqual(new Set(['newValue6']));
         })().then(done, done.fail);
     });
 
@@ -184,7 +184,7 @@ describe('Transaction', () => {
                 expect(key).toBe(`key${i}`);
                 --i;
                 return true;
-            }, false, JDB.KeyRange.bound('key3', 'key6'));
+            }, false, KeyRange.bound('key3', 'key6'));
             expect(i).toBe(2);
 
             i = 5;
@@ -192,7 +192,7 @@ describe('Transaction', () => {
                 expect(key).toBe(`key${i}`);
                 ++i;
                 return i < 7;
-            }, true, JDB.KeyRange.lowerBound('key4', true));
+            }, true, KeyRange.lowerBound('key4', true));
             expect(i).toBe(7);
         })().then(done, done.fail);
     });
@@ -226,7 +226,7 @@ describe('Transaction', () => {
                 expect(key).toBe(`key${i}`);
                 --i;
                 return true;
-            }, false, JDB.KeyRange.bound('key3', 'key6'));
+            }, false, KeyRange.bound('key3', 'key6'));
             expect(i).toBe(2);
 
             i = 5;
@@ -235,7 +235,7 @@ describe('Transaction', () => {
                 expect(key).toBe(`key${i}`);
                 ++i;
                 return i < 7;
-            }, true, JDB.KeyRange.lowerBound('key4', true));
+            }, true, KeyRange.lowerBound('key4', true));
             expect(i).toBe(7);
         })().then(done, done.fail);
     });

--- a/src/test/generic/TransactionBinaryCodec.spec.js
+++ b/src/test/generic/TransactionBinaryCodec.spec.js
@@ -16,7 +16,7 @@ describe('Transaction with binary codec', () => {
     }
 
     beforeEach((done) => {
-        objectStore = JDB.JungleDB.createVolatileObjectStore(JDB.BinaryCodec.instance);
+        objectStore = JungleDB.createVolatileObjectStore(BinaryCodec.instance);
         allKeys = new Set();
         allValues = new Set();
 
@@ -50,9 +50,9 @@ describe('Transaction with binary codec', () => {
         (async function () {
             // Ordering on strings might not be as expected!
             expect(await tx.keys()).toEqual(allKeys);
-            expect(await tx.keys(JDB.KeyRange.upperBound('key5'))).toEqual(new Set(['key1', 'key2', 'key3', 'key4', 'key5', 'key10', 'key11', 'key12', 'key13', 'key14']));
-            expect(await tx.keys(JDB.KeyRange.lowerBound('key1', true))).toEqual(allKeys.difference(['key1']));
-            expect(await tx.keys(JDB.KeyRange.lowerBound('key5', true))).toEqual(new Set(['key6', 'key7', 'key8', 'key9']));
+            expect(await tx.keys(KeyRange.upperBound('key5'))).toEqual(new Set(['key1', 'key2', 'key3', 'key4', 'key5', 'key10', 'key11', 'key12', 'key13', 'key14']));
+            expect(await tx.keys(KeyRange.lowerBound('key1', true))).toEqual(allKeys.difference(['key1']));
+            expect(await tx.keys(KeyRange.lowerBound('key5', true))).toEqual(new Set(['key6', 'key7', 'key8', 'key9']));
 
             expect(subValue(await tx.values())).toEqual(allValues);
         })().then(done, done.fail);
@@ -62,15 +62,15 @@ describe('Transaction with binary codec', () => {
         (async function () {
             expect(await tx.minKey()).toBe('key1');
             expect(await tx.maxKey()).toBe('key9');
-            expect(await tx.minKey(JDB.KeyRange.upperBound('key5'))).toBe('key1');
-            expect(await tx.minKey(JDB.KeyRange.lowerBound('key1', true))).toBe('key10');
-            expect(await tx.minKey(JDB.KeyRange.lowerBound('key5', true))).toBe('key6');
+            expect(await tx.minKey(KeyRange.upperBound('key5'))).toBe('key1');
+            expect(await tx.minKey(KeyRange.lowerBound('key1', true))).toBe('key10');
+            expect(await tx.minKey(KeyRange.lowerBound('key5', true))).toBe('key6');
 
             expect((await tx.minValue()).sub).toBe('value1');
             expect((await tx.maxValue()).sub).toBe('newValue9');
-            expect((await tx.minValue(JDB.KeyRange.upperBound('key5'))).sub).toBe('value1');
-            expect((await tx.minValue(JDB.KeyRange.lowerBound('key1', true))).sub).toBe('newValue10');
-            expect((await tx.minValue(JDB.KeyRange.lowerBound('key5', true))).sub).toBe('newValue6');
+            expect((await tx.minValue(KeyRange.upperBound('key5'))).sub).toBe('value1');
+            expect((await tx.minValue(KeyRange.lowerBound('key1', true))).sub).toBe('newValue10');
+            expect((await tx.minValue(KeyRange.lowerBound('key5', true))).sub).toBe('newValue6');
         })().then(done, done.fail);
     });
 
@@ -123,15 +123,15 @@ describe('Transaction with binary codec', () => {
             const index = tx.index('i');
             expect(await index.minKeys()).toEqual(new Set(['key1']));
             expect(await index.maxKeys()).toEqual(new Set(['key14']));
-            expect(await index.minKeys(JDB.KeyRange.upperBound(5))).toEqual(new Set(['key1']));
-            expect(await index.minKeys(JDB.KeyRange.lowerBound(1, true))).toEqual(new Set(['key2']));
-            expect(await index.minKeys(JDB.KeyRange.lowerBound(5, true))).toEqual(new Set(['key6']));
+            expect(await index.minKeys(KeyRange.upperBound(5))).toEqual(new Set(['key1']));
+            expect(await index.minKeys(KeyRange.lowerBound(1, true))).toEqual(new Set(['key2']));
+            expect(await index.minKeys(KeyRange.lowerBound(5, true))).toEqual(new Set(['key6']));
 
             expect(subValue(await index.minValues())).toEqual(new Set(['value1']));
             expect(subValue(await index.maxValues())).toEqual(new Set(['newValue14']));
-            expect(subValue(await index.minValues(JDB.KeyRange.upperBound(5)))).toEqual(new Set(['value1']));
-            expect(subValue(await index.minValues(JDB.KeyRange.lowerBound(1, true)))).toEqual(new Set(['value2']));
-            expect(subValue(await index.minValues(JDB.KeyRange.lowerBound(5, true)))).toEqual(new Set(['newValue6']));
+            expect(subValue(await index.minValues(KeyRange.upperBound(5)))).toEqual(new Set(['value1']));
+            expect(subValue(await index.minValues(KeyRange.lowerBound(1, true)))).toEqual(new Set(['value2']));
+            expect(subValue(await index.minValues(KeyRange.lowerBound(5, true)))).toEqual(new Set(['newValue6']));
         })().then(done, done.fail);
     });
 });

--- a/src/test/generic/TransactionInMemoryBackend.spec.js
+++ b/src/test/generic/TransactionInMemoryBackend.spec.js
@@ -16,7 +16,7 @@ describe('Transaction with InMemoryBackend', () => {
     }
 
     beforeEach((done) => {
-        objectStore = JDB.JungleDB.createVolatileObjectStore();
+        objectStore = JungleDB.createVolatileObjectStore();
         allKeys = new Set();
         allValues = new Set();
 
@@ -50,9 +50,9 @@ describe('Transaction with InMemoryBackend', () => {
         (async function () {
             // Ordering on strings might not be as expected!
             expect(await tx.keys()).toEqual(allKeys);
-            expect(await tx.keys(JDB.KeyRange.upperBound('key5'))).toEqual(new Set(['key1', 'key2', 'key3', 'key4', 'key5', 'key10', 'key11', 'key12', 'key13', 'key14']));
-            expect(await tx.keys(JDB.KeyRange.lowerBound('key1', true))).toEqual(allKeys.difference(['key1']));
-            expect(await tx.keys(JDB.KeyRange.lowerBound('key5', true))).toEqual(new Set(['key6', 'key7', 'key8', 'key9']));
+            expect(await tx.keys(KeyRange.upperBound('key5'))).toEqual(new Set(['key1', 'key2', 'key3', 'key4', 'key5', 'key10', 'key11', 'key12', 'key13', 'key14']));
+            expect(await tx.keys(KeyRange.lowerBound('key1', true))).toEqual(allKeys.difference(['key1']));
+            expect(await tx.keys(KeyRange.lowerBound('key5', true))).toEqual(new Set(['key6', 'key7', 'key8', 'key9']));
 
             expect(subValue(await tx.values())).toEqual(allValues);
         })().then(done, done.fail);
@@ -62,15 +62,15 @@ describe('Transaction with InMemoryBackend', () => {
         (async function () {
             expect(await tx.minKey()).toBe('key1');
             expect(await tx.maxKey()).toBe('key9');
-            expect(await tx.minKey(JDB.KeyRange.upperBound('key5'))).toBe('key1');
-            expect(await tx.minKey(JDB.KeyRange.lowerBound('key1', true))).toBe('key10');
-            expect(await tx.minKey(JDB.KeyRange.lowerBound('key5', true))).toBe('key6');
+            expect(await tx.minKey(KeyRange.upperBound('key5'))).toBe('key1');
+            expect(await tx.minKey(KeyRange.lowerBound('key1', true))).toBe('key10');
+            expect(await tx.minKey(KeyRange.lowerBound('key5', true))).toBe('key6');
 
             expect((await tx.minValue()).sub).toBe('value1');
             expect((await tx.maxValue()).sub).toBe('newValue9');
-            expect((await tx.minValue(JDB.KeyRange.upperBound('key5'))).sub).toBe('value1');
-            expect((await tx.minValue(JDB.KeyRange.lowerBound('key1', true))).sub).toBe('newValue10');
-            expect((await tx.minValue(JDB.KeyRange.lowerBound('key5', true))).sub).toBe('newValue6');
+            expect((await tx.minValue(KeyRange.upperBound('key5'))).sub).toBe('value1');
+            expect((await tx.minValue(KeyRange.lowerBound('key1', true))).sub).toBe('newValue10');
+            expect((await tx.minValue(KeyRange.lowerBound('key5', true))).sub).toBe('newValue6');
         })().then(done, done.fail);
     });
 
@@ -123,15 +123,15 @@ describe('Transaction with InMemoryBackend', () => {
             const index = tx.index('i');
             expect(await index.minKeys()).toEqual(new Set(['key1']));
             expect(await index.maxKeys()).toEqual(new Set(['key14']));
-            expect(await index.minKeys(JDB.KeyRange.upperBound(5))).toEqual(new Set(['key1']));
-            expect(await index.minKeys(JDB.KeyRange.lowerBound(1, true))).toEqual(new Set(['key2']));
-            expect(await index.minKeys(JDB.KeyRange.lowerBound(5, true))).toEqual(new Set(['key6']));
+            expect(await index.minKeys(KeyRange.upperBound(5))).toEqual(new Set(['key1']));
+            expect(await index.minKeys(KeyRange.lowerBound(1, true))).toEqual(new Set(['key2']));
+            expect(await index.minKeys(KeyRange.lowerBound(5, true))).toEqual(new Set(['key6']));
 
             expect(subValue(await index.minValues())).toEqual(new Set(['value1']));
             expect(subValue(await index.maxValues())).toEqual(new Set(['newValue14']));
-            expect(subValue(await index.minValues(JDB.KeyRange.upperBound(5)))).toEqual(new Set(['value1']));
-            expect(subValue(await index.minValues(JDB.KeyRange.lowerBound(1, true)))).toEqual(new Set(['value2']));
-            expect(subValue(await index.minValues(JDB.KeyRange.lowerBound(5, true)))).toEqual(new Set(['newValue6']));
+            expect(subValue(await index.minValues(KeyRange.upperBound(5)))).toEqual(new Set(['value1']));
+            expect(subValue(await index.minValues(KeyRange.lowerBound(1, true)))).toEqual(new Set(['value2']));
+            expect(subValue(await index.minValues(KeyRange.lowerBound(5, true)))).toEqual(new Set(['newValue6']));
         })().then(done, done.fail);
     });
 });

--- a/src/test/generic/utils/BufferUtils.spec.js
+++ b/src/test/generic/utils/BufferUtils.spec.js
@@ -1,0 +1,9 @@
+describe('BufferUtils', () => {
+
+    it('has fromBase64 and toBase64 methods', () => {
+        expect(BufferUtils.toBase64(BufferUtils.fromBase64('dGVzdA=='))).toEqual('dGVzdA==');
+        // Also allow eqs to be missing in input
+        expect(BufferUtils.toBase64(BufferUtils.fromBase64('dGVzdA'))).toEqual('dGVzdA==');
+    });
+
+});

--- a/src/test/generic/utils/JSONUtils.spec.js
+++ b/src/test/generic/utils/JSONUtils.spec.js
@@ -1,0 +1,62 @@
+describe('JSONUtils', () => {
+
+    const simpleObjects = [
+        {
+            a: [1, 2, 3],
+            b: 'test'
+        },
+        {
+            a: [1, 2, 3],
+            b: {
+                c: 5,
+                d: '6'
+            }
+        }
+    ];
+
+    it('can stringify simple objects', () => {
+        for (const o of simpleObjects) {
+            expect(JSONUtils.stringify(o)).toBe(JSON.stringify(o));
+        }
+    });
+
+    it('can parse simple objects', () => {
+        for (const o of simpleObjects) {
+            expect(JSONUtils.stringify(JSONUtils.parse(JSON.stringify(o)))).toBe(JSON.stringify(o));
+        }
+    });
+
+    it('can convert complex objects', () => {
+        let obj = { a: new Uint8Array(10) };
+        let obj2 = JSONUtils.parse(JSONUtils.stringify(obj));
+
+        // Compare objects.
+        expect(obj2.a instanceof Uint8Array).toBe(true);
+        expect(obj2.a.length).toBe(10);
+        for (let i = 0; i < 10; ++i) {
+            expect(obj2.a[i]).toBe(0);
+        }
+
+        obj = { a: Set.from([1, 2, 3]) };
+        obj2 = JSONUtils.parse(JSONUtils.stringify(obj));
+
+        // Compare objects.
+        expect(obj2.a instanceof Set).toBe(true);
+        expect(obj2.a.size).toBe(3);
+        for (let i = 0; i < 3; ++i) {
+            expect(obj2.a.has(i+1)).toBe(true);
+        }
+
+        obj = { a: new Uint8Array(10), b: 5 };
+        obj2 = JSONUtils.parse(JSONUtils.stringify(obj));
+
+        // Compare objects.
+        expect(obj2.a instanceof Uint8Array).toBe(true);
+        expect(obj2.a.length).toBe(10);
+        for (let i = 0; i < 10; ++i) {
+            expect(obj2.a[i]).toBe(0);
+        }
+        expect(obj2.b).toBe(5);
+    });
+
+});

--- a/src/test/generic/utils/LRUMap.spec.js
+++ b/src/test/generic/utils/LRUMap.spec.js
@@ -1,7 +1,7 @@
 describe('LRUMap', () => {
 
     it('does can store key-value pairs', () => {
-        const lru = new JDB.LRUMap(10);
+        const lru = new LRUMap(10);
 
         // Fill map.
         for (let i=0; i<10; ++i) {
@@ -15,7 +15,7 @@ describe('LRUMap', () => {
     });
 
     it('evicts old entries', () => {
-        const lru = new JDB.LRUMap(2);
+        const lru = new LRUMap(2);
 
         // Fill map.
         for (let i=0; i<3; ++i) {
@@ -29,7 +29,7 @@ describe('LRUMap', () => {
     });
 
     it('does not evict recently accessed entries', () => {
-        const lru = new JDB.LRUMap(2);
+        const lru = new LRUMap(2);
 
         // Fill map.
         for (let i=0; i<3; ++i) {
@@ -46,7 +46,7 @@ describe('LRUMap', () => {
     });
 
     it('has a working iterator', () => {
-        const lru = new JDB.LRUMap(3);
+        const lru = new LRUMap(3);
 
         // Fill map.
         for (let i=0; i<3; ++i) {
@@ -64,7 +64,7 @@ describe('LRUMap', () => {
     });
 
     it('can evict multiple entries', () => {
-        const lru = new JDB.LRUMap(3);
+        const lru = new LRUMap(3);
 
         // Fill map.
         for (let i=0; i<3; ++i) {
@@ -81,7 +81,7 @@ describe('LRUMap', () => {
     });
 
     it('can be cleared', () => {
-        const lru = new JDB.LRUMap(3);
+        const lru = new LRUMap(3);
 
         // Fill map.
         for (let i=0; i<3; ++i) {
@@ -98,7 +98,7 @@ describe('LRUMap', () => {
     });
 
     it('does not exceed maxSize', () => {
-        const lru = new JDB.LRUMap(3);
+        const lru = new LRUMap(3);
 
         lru.access('test');
 

--- a/src/test/generic/utils/ObjectUtils.spec.js
+++ b/src/test/generic/utils/ObjectUtils.spec.js
@@ -4,7 +4,7 @@ describe('ObjectUtils', () => {
         const obj = {
             test: 'success'
         };
-        expect(JDB.ObjectUtils.byKeyPath(obj, 'test')).toEqual('success');
+        expect(ObjectUtils.byKeyPath(obj, 'test')).toEqual('success');
     });
 
     it('correctly retrieves complex properties from objects', () => {
@@ -15,7 +15,7 @@ describe('ObjectUtils', () => {
                 }
             }
         };
-        expect(JDB.ObjectUtils.byKeyPath(obj, 'complex|test|case'.split('|'))).toEqual('success');
+        expect(ObjectUtils.byKeyPath(obj, 'complex|test|case'.split('|'))).toEqual('success');
     });
 
     it('correctly retrieves simple properties from classes', () => {
@@ -29,8 +29,8 @@ describe('ObjectUtils', () => {
             }
         }
         const obj = new Test();
-        expect(JDB.ObjectUtils.byKeyPath(obj, 'test')).toEqual('success');
-        expect(JDB.ObjectUtils.byKeyPath(obj, 'test2')).toEqual('member');
+        expect(ObjectUtils.byKeyPath(obj, 'test')).toEqual('success');
+        expect(ObjectUtils.byKeyPath(obj, 'test2')).toEqual('member');
     });
 
     it('correctly retrieves complex properties from classes', () => {
@@ -46,7 +46,7 @@ describe('ObjectUtils', () => {
             }
         }
         const obj = new Test();
-        expect(JDB.ObjectUtils.byKeyPath(obj, '_privateTest|another'.split('|'))).toEqual('example');
-        expect(JDB.ObjectUtils.byKeyPath(obj, 'test|_privateTest|another'.split('|'))).toEqual('example');
+        expect(ObjectUtils.byKeyPath(obj, '_privateTest|another'.split('|'))).toEqual('example');
+        expect(ObjectUtils.byKeyPath(obj, 'test|_privateTest|another'.split('|'))).toEqual('example');
     });
 });

--- a/src/test/platform/browser/BinaryCodec.js
+++ b/src/test/platform/browser/BinaryCodec.js
@@ -34,7 +34,7 @@ class BinaryCodec {
      * @type {{encode: function(val:*):*, decode: function(val:*):*, buffer: boolean, type: string}|void}
      */
     get valueEncoding() {
-        return JDB.JungleDB.JSON_ENCODING;
+        return JungleDB.JSON_ENCODING;
     }
 }
-JDB.Class.register(BinaryCodec);
+Class.register(BinaryCodec);

--- a/src/test/platform/browser/spec.js
+++ b/src/test/platform/browser/spec.js
@@ -1,0 +1,1 @@
+var JDB = window;

--- a/src/test/platform/nodejs/BinaryCodec.js
+++ b/src/test/platform/nodejs/BinaryCodec.js
@@ -49,4 +49,4 @@ class BinaryCodec {
         return 'binary';
     }
 }
-JDB.Class.register(BinaryCodec);
+Class.register(BinaryCodec);

--- a/src/test/platform/nodejs/spec.js
+++ b/src/test/platform/nodejs/spec.js
@@ -1,41 +1,13 @@
-global.JDB = {};
+const JDB = require('../../../../dist/node.js');
+for(let i in JDB) global[i] = JDB[i];
+global.JDB = JDB;
 
 global.Class = {
     register: clazz => {
-        global.JDB[clazz.prototype.constructor.name] = clazz;
         global[clazz.prototype.constructor.name] = clazz;
     }
 };
 
-global.JDB.Class = global.Class;
-
-process.on('unhandledRejection', console.error);
-
 require('../../generic/DummyBackend.js');
+require('./BinaryCodec.js');
 require('../../generic/TestCodec.js');
-require('../../platform/nodejs/BinaryCodec.js');
-
-require('../../../main/generic/utils/BTree.js');
-require('../../../main/generic/utils/LRUMap.js');
-require('../../../main/generic/utils/ObjectUtils.js');
-require('../../../main/generic/utils/Observable.js');
-require('../../../main/generic/utils/Synchronizer.js');
-require('../../../main/generic/utils/ArrayUtils.js');
-require('../../../main/generic/utils/SetUtils.js');
-require('../../../main/generic/CachedBackend.js');
-require('../../../main/generic/InMemoryIndex.js');
-require('../../../main/generic/InMemoryBackend.js');
-require('../../../main/generic/KeyRange.js');
-require('../../../main/generic/ObjectStore.js');
-require('../../../main/generic/Query.js');
-require('../../../main/generic/TransactionIndex.js');
-require('../../../main/generic/Transaction.js');
-require('../../../main/generic/Snapshot.js');
-require('../../../main/generic/SnapshotManager.js');
-require('../../../main/generic/CombinedTransaction.js');
-
-require('../../../main/platform/nodejs/utils/LevelDBTools.js');
-require('../../../main/platform/nodejs/utils/IndexCodec.js');
-require('../../../main/platform/nodejs/PersistentIndex.js');
-require('../../../main/platform/nodejs/LevelDBBackend.js');
-require('../../../main/platform/nodejs/JungleDB.js');

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,7 +381,7 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-atob@^2.0.0:
+atob@^2.0.0, atob@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
@@ -1285,6 +1285,10 @@ browserslist@^2.1.2:
   dependencies:
     caniuse-lite "^1.0.30000780"
     electron-to-chromium "^1.3.28"
+
+btoa@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.1.2.tgz#3e40b81663f81d2dd6596a4cb714a8dc16cfabe0"
 
 buffer-crc32@^0.2.1:
   version "0.2.13"


### PR DESCRIPTION
The new encoding can remember types and saves space when storing Uint8Arrays.
Also increases the version number and simplifies access to JDB objects in tests.