### PR TITLE
Fix of issue #14

### DIFF
--- a/src/test/generic/CombinedTransaction.spec.js
+++ b/src/test/generic/CombinedTransaction.spec.js
@@ -285,10 +285,19 @@ describe('CombinedTransaction', () => {
             expect(objectStore1._stateStack.length).toBe(2);
             expect(objectStore2._stateStack.length).toBe(2);
 
+            tx1 = objectStore1.transaction();
+            tx2 = objectStore2.transaction();
+            await tx1.remove('key4');
+            await tx2.remove('key4');
+
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(objectStore1._stateStack.length).toBe(3);
+            expect(objectStore2._stateStack.length).toBe(3);
+
             await blockingTx1.abort();
 
-            expect(objectStore1._stateStack.length).toBe(2);
-            expect(objectStore2._stateStack.length).toBe(2);
+            expect(objectStore1._stateStack.length).toBe(3);
+            expect(objectStore2._stateStack.length).toBe(3);
 
             await blockingTx2.abort();
 

--- a/src/test/generic/CombinedTransactionPlatform.spec.js
+++ b/src/test/generic/CombinedTransactionPlatform.spec.js
@@ -292,10 +292,19 @@ describe('CombinedTransactionPlatform', () => {
             expect(objectStore1._stateStack.length).toBe(2);
             expect(objectStore2._stateStack.length).toBe(2);
 
+            tx1 = objectStore1.transaction();
+            tx2 = objectStore2.transaction();
+            await tx1.remove('key4');
+            await tx2.remove('key4');
+
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(objectStore1._stateStack.length).toBe(3);
+            expect(objectStore2._stateStack.length).toBe(3);
+
             await blockingTx1.abort();
 
-            expect(objectStore1._stateStack.length).toBe(2);
-            expect(objectStore2._stateStack.length).toBe(2);
+            expect(objectStore1._stateStack.length).toBe(3);
+            expect(objectStore2._stateStack.length).toBe(3);
 
             await blockingTx2.abort();
 

--- a/src/test/generic/CombinedTransactionPlatform.spec.js
+++ b/src/test/generic/CombinedTransactionPlatform.spec.js
@@ -268,4 +268,39 @@ describe('CombinedTransactionPlatform', () => {
             expect(await objectStore1.get('key6')).toBe('newvalue6');
         })().then(done, done.fail);
     });
+
+    it('does not infinitely stack combined transactions', (done) => {
+        (async function () {
+            const blockingTx1 = objectStore1.transaction();
+            const blockingTx2 = objectStore2.transaction();
+
+            let tx1 = objectStore1.transaction();
+            let tx2 = objectStore2.transaction();
+            await tx1.remove('key6');
+            await tx2.remove('key6');
+
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(objectStore1._stateStack.length).toBe(1);
+            expect(objectStore2._stateStack.length).toBe(1);
+
+            tx1 = objectStore1.transaction();
+            tx2 = objectStore2.transaction();
+            await tx1.remove('key5');
+            await tx2.remove('key5');
+
+            expect(await JungleDB.commitCombined(tx1, tx2)).toBe(true);
+            expect(objectStore1._stateStack.length).toBe(2);
+            expect(objectStore2._stateStack.length).toBe(2);
+
+            await blockingTx1.abort();
+
+            expect(objectStore1._stateStack.length).toBe(2);
+            expect(objectStore2._stateStack.length).toBe(2);
+
+            await blockingTx2.abort();
+
+            expect(objectStore1._stateStack.length).toBe(0);
+            expect(objectStore2._stateStack.length).toBe(0);
+        })().then(done, done.fail);
+    });
 });


### PR DESCRIPTION
Issue #14 arises in the following scenario:
* There are two object stores **OS1** and **OS2**. Moreover, there are four transactions *tx1_1*, *tx2_1*, *tx1_2*, and *tx2_2*, where the *_x* part denotes the object store the transactions are based on.
![step1](https://user-images.githubusercontent.com/13586855/34166891-c535d520-e4a5-11e7-85db-ea11adc45617.png)

* *tx1_1* and *tx1_2* are committed as a combined transaction. However, they can not be written to the backend, since transactions *tx2_1* and *tx2_2* are still open.
![step2](https://user-images.githubusercontent.com/13586855/34166890-c51d3aec-e4a5-11e7-93a7-ae9c312c73a5.png)

* Two more transactions *tx3_1* and *tx3_2* are opened on the base states *tx1_1* and *tx1_2*. *tx3_1* and *tx3_2* are committed as a combined transaction and extend the state stack.
![step3](https://user-images.githubusercontent.com/13586855/34166889-c4fe74d6-e4a5-11e7-868f-958f6b8d91bc.png)

* *tx2_1* is aborted, *tx1_1* is thus marked as flushable.
![step4](https://user-images.githubusercontent.com/13586855/34166888-c4dff056-e4a5-11e7-97ff-8a1cfa97bedb.png)
7. *tx2_2* is aborted, *tx1_2* is thus marked as flushable. This starts the combined commit of *tx1_1* and *tx1_2*. Since the flush to the backend is triggered by **OS2**, `_flattenState` is only called again on this object store, marking *tx3_2* as flushable.
![step5](https://user-images.githubusercontent.com/13586855/34166886-c4c850c2-e4a5-11e7-99c1-90a8d3e3024a.png)

* This, however, leaves *tx3_1* as non-flushable and the state stack won't be flattened anymore.
![step6](https://user-images.githubusercontent.com/13586855/34166885-c4af42f8-e4a5-11e7-953f-a8ad4ea092fe.png)

The fix we deployed always triggers `_flattenState` during the cleanup of a successful commit and hence will also mark *tx3_1* as flushable.