### PR TITLE
catch sync callback exceptions

### DIFF
--- a/src/main/generic/InMemoryBackend.js
+++ b/src/main/generic/InMemoryBackend.js
@@ -47,7 +47,11 @@ class InMemoryBackend {
      * @returns {Promise.<*>}
      */
     get(key) {
-        return Promise.resolve(this.getSync(key));
+        try {
+            return Promise.resolve(this.getSync(key));
+        } catch(e) {
+            return Promise.reject(e);
+        }
     }
 
     /**

--- a/src/main/platform/browser/IDBBackend.js
+++ b/src/main/platform/browser/IDBBackend.js
@@ -106,7 +106,7 @@ class IDBBackend {
             getTx.onsuccess = event => {
                 try {
                     resolve(this.decode(event.target.result, key));
-                } catch(e) {
+                } catch (e) {
                     reject(e);
                 }
             };
@@ -169,7 +169,11 @@ class IDBBackend {
             openCursorRequest.onsuccess = event => {
                 const cursor = event.target.result;
                 if (cursor) {
-                    results.push(this.decode(cursor.value, cursor.primaryKey));
+                    try {
+                        results.push(this.decode(cursor.value, cursor.primaryKey));
+                    } catch (e) {
+                        reject(e);
+                    }
                     cursor.continue();
                 } else {
                     resolve(results);
@@ -262,10 +266,14 @@ class IDBBackend {
             openCursorRequest.onsuccess = event => {
                 const cursor = event.target.result;
                 if (cursor) {
-                    if (callback(cursor.value, cursor.primaryKey)) {
-                        cursor.continue();
-                    } else {
-                        resolve();
+                    try {
+                        if (callback(this.decode(cursor.value, cursor.primaryKey), cursor.primaryKey)) {
+                            cursor.continue();
+                        } else {
+                            resolve();
+                        }
+                    } catch (e) {
+                        reject(e);
                     }
                 } else {
                     resolve();
@@ -293,7 +301,7 @@ class IDBBackend {
                 try {
                     const cursor = event.target.result;
                     resolve(cursor ? this.decode(cursor.value, cursor.primaryKey) : undefined);
-                } catch(e) {
+                } catch (e) {
                     reject(e);
                 }
             };
@@ -337,7 +345,7 @@ class IDBBackend {
                 try {
                     const cursor = event.target.result;
                     resolve(cursor ? this.decode(cursor.value, cursor.primaryKey) : undefined);
-                } catch(e) {
+                } catch (e) {
                     reject(e);
                 }
             };

--- a/src/main/platform/browser/IDBBackend.js
+++ b/src/main/platform/browser/IDBBackend.js
@@ -103,7 +103,13 @@ class IDBBackend {
             const getTx = db.transaction([this._tableName])
                 .objectStore(this._tableName)
                 .get(key);
-            getTx.onsuccess = event => resolve(this.decode(event.target.result, key));
+            getTx.onsuccess = event => {
+                try {
+                    resolve(this.decode(event.target.result, key));
+                } catch(e) {
+                    reject(e);
+                }
+            };
             getTx.onerror = reject;
         });
     }
@@ -284,8 +290,12 @@ class IDBBackend {
                 .objectStore(this._tableName)
                 .openCursor(query, 'prev');
             openCursorRequest.onsuccess = event => {
-                const cursor = event.target.result;
-                resolve(cursor ? this.decode(cursor.value, cursor.primaryKey) : undefined);
+                try {
+                    const cursor = event.target.result;
+                    resolve(cursor ? this.decode(cursor.value, cursor.primaryKey) : undefined);
+                } catch(e) {
+                    reject(e);
+                }
             };
             openCursorRequest.onerror = () => reject(openCursorRequest.error);
         });
@@ -324,8 +334,12 @@ class IDBBackend {
                 .objectStore(this._tableName)
                 .openCursor(query, 'next');
             openCursorRequest.onsuccess = event => {
-                const cursor = event.target.result;
-                resolve(cursor ? this.decode(cursor.value, cursor.primaryKey) : undefined);
+                try {
+                    const cursor = event.target.result;
+                    resolve(cursor ? this.decode(cursor.value, cursor.primaryKey) : undefined);
+                } catch(e) {
+                    reject(e);
+                }
             };
             openCursorRequest.onerror = () => reject(openCursorRequest.error);
         });

--- a/src/main/platform/nodejs/LevelDBBackend.js
+++ b/src/main/platform/nodejs/LevelDBBackend.js
@@ -116,7 +116,11 @@ class LevelDBBackend {
                     resolve(undefined);
                     return;
                 }
-                resolve(this.decode(value, key));
+                try {
+                    resolve(this.decode(value, key));
+                } catch(e) {
+                    error(e);
+                }
             });
         });
     }
@@ -314,7 +318,11 @@ class LevelDBBackend {
         return new Promise((resolve, error) => {
             this._dbBackend.createReadStream(LevelDBTools.convertKeyRange(query, { 'values': true, 'keys': true, 'limit': 1, 'reverse': true }))
                 .on('data', data => {
-                    resolve(this.decode(data.value, data.key));
+                    try {
+                        resolve(this.decode(data.value, data.key));
+                    } catch(e) {
+                        error(e);
+                    }
                 })
                 .on('error', err => {
                     error(err);
@@ -352,7 +360,11 @@ class LevelDBBackend {
         return new Promise((resolve, error) => {
             this._dbBackend.createReadStream(LevelDBTools.convertKeyRange(query, { 'values': true, 'keys': true, 'limit': 1, 'reverse': false }))
                 .on('data', data => {
-                    resolve(this.decode(data.value, data.key));
+                    try {
+                        resolve(this.decode(data.value, data.key));
+                    } catch(e) {
+                        error(e);
+                    }
                 })
                 .on('error', err => {
                     error(err);


### PR DESCRIPTION
Catch sync exceptions in success callbacks and sync methods returning a promise and emit a promise rejection. These exceptions would otherwise be unhandled exceptions and the promise never resolve nor reject.

Please check whether a Promise rejection is the desired behavior everywhere or whether some promises should resolve with undefined.