### PR TITLE
Implement unique indices for all backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Depending on your target and preferences, include one of the files in the dist f
 In NodeJS, you can use `var JDB = require('@nimiq/jungle-db');` to include the LMDB backend.
 In order to use the LevelDB backend, `var JDB = require('@nimiq/jungle-db/dist/leveldb.js');` has to be used.
 
+**Note on Edge browser:** At the time of writing, Edge does not provide full IndexedDB support.
+That means that using certain types of indices might fail on Edge.
+If you observe a `DataError` in Edge while using JungleDB,
+it is most likely that you are using one of the features not supported by Edge.
+
 Then, create a `JungleDB` instance and potential object stores as follows:
 ```javascript
 // Create a JungleDB instance

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -206,7 +206,7 @@ gulp.task('build-leveldb', function () {
     return gulp.src(LEVELDB_SOURCES, { base: 'src' })
         .pipe(sourcemaps.init())
         .pipe(concat('leveldb.js'))
-        .pipe(uglify(uglify_config))
+        // .pipe(uglify(uglify_config))
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest('dist'));
 });
@@ -231,7 +231,7 @@ gulp.task('build-lmdb', function () {
     return gulp.src(LMDB_SOURCES, { base: 'src' })
         .pipe(sourcemaps.init())
         .pipe(concat('lmdb.js'))
-        .pipe(uglify(uglify_config))
+        // .pipe(uglify(uglify_config))
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest('dist'));
 });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "level-sublevel": "^6.6.1",
     "leveldown": "^3.0.0",
     "levelup": "^2.0.2",
-    "node-lmdb": "Venemo/node-lmdb"
+    "node-lmdb": "Venemo/node-lmdb#d9eb604"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "level-sublevel": "^6.6.1",
     "leveldown": "^3.0.0",
     "levelup": "^2.0.2",
-    "node-lmdb": "Venemo/node-lmdb#d9eb604"
+    "node-lmdb": "Venemo/node-lmdb#024bd35"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/src/main/backend/indexeddb/IDBBackend.js
+++ b/src/main/backend/indexeddb/IDBBackend.js
@@ -62,7 +62,7 @@ class IDBBackend {
         for (const [indexName, { index, upgradeCondition }] of this._indicesToCreate) {
             if (upgradeCondition === null || upgradeCondition === true || (typeof upgradeCondition === 'function' && upgradeCondition(oldVersion, newVersion))) {
                 const keyPath = Array.isArray(index.keyPath) ? index.keyPath.join('.') : index.keyPath;
-                objectStore.createIndex(indexName, keyPath, {unique: false, multiEntry: index.multiEntry});
+                objectStore.createIndex(indexName, keyPath, {unique: index.unique, multiEntry: index.multiEntry});
             }
         }
         this._indicesToCreate.clear();
@@ -481,15 +481,15 @@ class IDBBackend {
      * Moreover, it is only executed on database version updates or on first creation.
      * @param {string} indexName The name of the index.
      * @param {string|Array.<string>} [keyPath] The path to the key within the object. May be an array for multiple levels.
-     * @param {{multiEntry:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
+     * @param {{multiEntry:?boolean, unique:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
      */
     createIndex(indexName, keyPath, options=false) {
-        let { multiEntry = false, upgradeCondition = null } = (typeof options === 'object' && options !== null) ? options : {};
+        let { multiEntry = false, upgradeCondition = null, unique = false } = (typeof options === 'object' && options !== null) ? options : {};
         if (typeof options !== 'object' && options !== null) multiEntry = options;
 
         if (this._db.connected) throw new Error('Cannot create index while connected');
         keyPath = keyPath || indexName;
-        const index = new PersistentIndex(this, indexName, keyPath, multiEntry);
+        const index = new PersistentIndex(this, indexName, keyPath, multiEntry, unique);
         this._indices.set(indexName, index);
         this._indicesToCreate.set(indexName, { index, upgradeCondition });
     }

--- a/src/main/backend/indexeddb/PersistentIndex.js
+++ b/src/main/backend/indexeddb/PersistentIndex.js
@@ -9,11 +9,12 @@ class PersistentIndex {
      * @param {string|Array.<string>} keyPath
      * @param {boolean} multiEntry
      */
-    constructor(objectStore, indexName, keyPath, multiEntry=false) {
+    constructor(objectStore, indexName, keyPath, multiEntry = false, unique = false) {
         this._objectStore = objectStore;
         this._indexName = indexName;
         this._keyPath = keyPath;
         this._multiEntry = multiEntry;
+        this._unique = unique;
     }
 
     /**
@@ -42,6 +43,14 @@ class PersistentIndex {
      */
     get multiEntry() {
         return this._multiEntry;
+    }
+
+    /**
+     * This value determines whether the index is a unique constraint.
+     * @type {boolean}
+     */
+    get unique() {
+        return this._unique;
     }
 
     /**

--- a/src/main/backend/indexeddb/PersistentIndex.js
+++ b/src/main/backend/indexeddb/PersistentIndex.js
@@ -7,7 +7,8 @@ class PersistentIndex {
      * @param {IDBBackend} objectStore
      * @param {string} indexName
      * @param {string|Array.<string>} keyPath
-     * @param {boolean} multiEntry
+     * @param {boolean} [multiEntry]
+     * @param {boolean} [unique]
      */
     constructor(objectStore, indexName, keyPath, multiEntry = false, unique = false) {
         this._objectStore = objectStore;

--- a/src/main/backend/leveldb/LevelDBBackend.js
+++ b/src/main/backend/leveldb/LevelDBBackend.js
@@ -594,15 +594,15 @@ class LevelDBBackend {
      * Moreover, it is only executed on database version updates or on first creation.
      * @param {string} indexName The name of the index.
      * @param {string|Array.<string>} [keyPath] The path to the key within the object. May be an array for multiple levels.
-     * @param {{multiEntry:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
+     * @param {{multiEntry:?boolean, unique:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
      */
     createIndex(indexName, keyPath, options=false) {
-        let { multiEntry = false, upgradeCondition = null } = (typeof options === 'object' && options !== null) ? options : {};
+        let { multiEntry = false, upgradeCondition = null, unique = false } = (typeof options === 'object' && options !== null) ? options : {};
         if (typeof options !== 'object' && options !== null) multiEntry = options;
 
         if (this._db.connected) throw new Error('Cannot create index while connected');
         keyPath = keyPath || indexName;
-        const index = new PersistentIndex(this, this._db, indexName, keyPath, multiEntry);
+        const index = new PersistentIndex(this, this._db, indexName, keyPath, multiEntry, unique);
         this._indices.set(indexName, index);
         this._indicesToCreate.set(indexName, { index, upgradeCondition });
     }

--- a/src/main/backend/lmdb/LMDBBackend.js
+++ b/src/main/backend/lmdb/LMDBBackend.js
@@ -398,15 +398,15 @@ class LMDBBackend extends LMDBBaseBackend {
      * Moreover, it is only executed on database version updates or on first creation.
      * @param {string} indexName The name of the index.
      * @param {string|Array.<string>} [keyPath] The path to the key within the object. May be an array for multiple levels.
-     * @param {{multiEntry:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
+     * @param {{multiEntry:?boolean, unique:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
      */
     createIndex(indexName, keyPath, options=false) {
-        let { multiEntry = false, upgradeCondition = null } = (typeof options === 'object' && options !== null) ? options : {};
+        let { multiEntry = false, upgradeCondition = null, unique = false } = (typeof options === 'object' && options !== null) ? options : {};
         if (typeof options !== 'object' && options !== null) multiEntry = options;
 
         if (this._db.connected) throw new Error('Cannot create index while connected');
         keyPath = keyPath || indexName;
-        const index = new PersistentIndex(this, this._db, indexName, keyPath, multiEntry);
+        const index = new PersistentIndex(this, this._db, indexName, keyPath, multiEntry, unique);
         this._indices.set(indexName, index);
         this._indicesToCreate.set(indexName, { index, upgradeCondition });
     }
@@ -472,7 +472,12 @@ class LMDBBackend extends LMDBBaseBackend {
         }
 
         const txn = this._env.beginTxn();
-        this.applyEncodedTransaction(encodedTx, txn);
+        try {
+            this.applyEncodedTransaction(encodedTx, txn);
+        } catch (e) {
+            txn.abort();
+            throw e;
+        }
         txn.commit();
     }
 }

--- a/src/main/backend/lmdb/PersistentIndex.js
+++ b/src/main/backend/lmdb/PersistentIndex.js
@@ -141,7 +141,10 @@ class PersistentIndex extends LMDBBaseBackend {
             super._remove(txn, key, tx.removedValue(key), true);
         }
         for (const [key, value] of tx._modified) {
-            super._put(txn, key, value, !this._unique, true);
+            const result = super._put(txn, key, value, !this._unique, true);
+            if (!result) {
+                throw new Error(`Uniqueness constraint violated for key ${value} on path ${this._keyPath}`);
+            }
         }
     }
 

--- a/src/main/generic/CachedBackend.js
+++ b/src/main/generic/CachedBackend.js
@@ -266,13 +266,10 @@ class CachedBackend {
      * Moreover, it is only executed on database version updates or on first creation.
      * @param {string} indexName The name of the index.
      * @param {string|Array.<string>} [keyPath] The path to the key within the object. May be an array for multiple levels.
-     * @param {{multiEntry:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
+     * @param {{multiEntry:?boolean, unique:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
      */
     createIndex(indexName, keyPath, options=false) {
-        let { multiEntry = false, upgradeCondition = null } = (typeof options === 'object' && options !== null) ? options : {};
-        if (typeof options !== 'object' && options !== null) multiEntry = options;
-
-        return this._backend.createIndex(indexName, keyPath, { multiEntry, upgradeCondition });
+        return this._backend.createIndex(indexName, keyPath, options);
     }
 
     /**

--- a/src/main/generic/InMemoryIndex.js
+++ b/src/main/generic/InMemoryIndex.js
@@ -74,6 +74,14 @@ class InMemoryIndex {
     }
 
     /**
+     * This value determines whether the index is a unique constraint.
+     * @type {boolean}
+     */
+    get unique() {
+        return this._unique;
+    }
+
+    /**
      * A helper method to insert a primary-secondary key pair into the tree.
      * @param {string} key The primary key.
      * @param {*} iKey The indexed key.

--- a/src/main/generic/ObjectStore.js
+++ b/src/main/generic/ObjectStore.js
@@ -484,13 +484,10 @@ class ObjectStore {
      * Moreover, it is only executed on database version updates or on first creation.
      * @param {string} indexName The name of the index.
      * @param {string|Array.<string>} [keyPath] The path to the key within the object. May be an array for multiple levels.
-     * @param {{multiEntry:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
+     * @param {{multiEntry:?boolean, unique:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
      */
     createIndex(indexName, keyPath, options=false) {
-        let { multiEntry = false, upgradeCondition = null } = (typeof options === 'object' && options !== null) ? options : {};
-        if (typeof options !== 'object' && options !== null) multiEntry = options;
-
-        return this._backend.createIndex(indexName, keyPath, { multiEntry, upgradeCondition });
+        return this._backend.createIndex(indexName, keyPath, options);
     }
 
     /**

--- a/src/main/generic/Transaction.js
+++ b/src/main/generic/Transaction.js
@@ -399,6 +399,13 @@ class Transaction {
             throw new Error('Transaction already closed');
         }
 
+        // Check indices.
+        const constraints = [];
+        for (const index of this._indices.values()) {
+            constraints.push(index.checkUniqueConstraint(key, value));
+        }
+        await Promise.all(constraints);
+
         const oldValue = await this.get(key);
 
         // Save for indices.

--- a/src/main/generic/interfaces/IIndex.js
+++ b/src/main/generic/interfaces/IIndex.js
@@ -37,6 +37,13 @@ class IIndex {
     get multiEntry() {} // eslint-disable-line no-unused-vars
 
     /**
+     * This value determines whether the index is a unique constraint.
+     * @abstract
+     * @type {boolean}
+     */
+    get unique() {} // eslint-disable-line no-unused-vars
+
+    /**
      * Returns a promise of a set of primary keys, whose associated objects' secondary keys are in the given range.
      * If the optional query is not given, it returns all primary keys in the index.
      * If the query is of type KeyRange, it returns all primary keys for which the secondary key is within this range.

--- a/src/main/generic/interfaces/IObjectStore.js
+++ b/src/main/generic/interfaces/IObjectStore.js
@@ -198,7 +198,7 @@ class IObjectStore {
      * @abstract
      * @param {string} indexName The name of the index.
      * @param {string|Array.<string>} [keyPath] The path to the key within the object. May be an array for multiple levels.
-     * @param {{multiEntry:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
+     * @param {{multiEntry:?boolean, unique:?boolean, upgradeCondition:?boolean|?function(oldVersion:number, newVersion:number):boolean}|boolean} [options] An options object (for deprecated usage: multiEntry boolean).
      */
     createIndex(indexName, keyPath, options=false) {} // eslint-disable-line no-unused-vars
 

--- a/src/test/generic/Index.spec.js
+++ b/src/test/generic/Index.spec.js
@@ -278,6 +278,15 @@ describe('Index', () => {
             }
             expect(threw).toBe(true);
 
+            threw = false;
+            const tx = st.transaction();
+            try {
+                await tx.put('test2', {'val': 123, 'a': {'b': 1}});
+            } catch (e) {
+                threw = true;
+            }
+            expect(threw).toBe(true);
+
             await db.destroy();
         })().then(done, done.fail);
     });

--- a/src/test/generic/Index.spec.js
+++ b/src/test/generic/Index.spec.js
@@ -259,4 +259,26 @@ describe('Index', () => {
             await db.destroy();
         })().then(done, done.fail);
     });
+
+    it('provides unique indices', (done) => {
+        (async function () {
+            debugger;
+            // Write something into an object store.
+            let db = new JungleDB('indexTest', 1);
+            let st = db.createObjectStore('testStore');
+            st.createIndex('depth', ['a', 'b'], { unique: true });
+            await db.connect();
+
+            await st.put('test', {'val': 123, 'a': {'b': 1}});
+            let threw = false;
+            try {
+                await st.put('test2', {'val': 123, 'a': {'b': 1}});
+            } catch (e) {
+                threw = true;
+            }
+            expect(threw).toBe(true);
+
+            await db.destroy();
+        })().then(done, done.fail);
+    });
 });

--- a/src/test/generic/Index.spec.js
+++ b/src/test/generic/Index.spec.js
@@ -169,6 +169,11 @@ describe('Index', () => {
 
     it('only fills the index once', (done) => {
         (async function () {
+            // Do not run this test in Edge.
+            if (typeof window !== 'undefined' && window.navigator.userAgent.indexOf("Edge") > -1) {
+                return;
+            }
+
             // Write something into an object store.
             let db = new JungleDB('indexTest', 1);
             let st = db.createObjectStore('testStore');
@@ -199,6 +204,11 @@ describe('Index', () => {
 
     it('can fill the index on implicit upgrade', (done) => {
         (async function () {
+            // Do not run this test in Edge.
+            if (typeof window !== 'undefined' && window.navigator.userAgent.indexOf("Edge") > -1) {
+                return;
+            }
+
             // Write something into an object store.
             let db = new JungleDB('indexTest', 1);
             let st = db.createObjectStore('testStore');
@@ -223,6 +233,11 @@ describe('Index', () => {
 
     it('can fill the index on explicit upgrade', (done) => {
         (async function () {
+            // Do not run this test in Edge.
+            if (typeof window !== 'undefined' && window.navigator.userAgent.indexOf("Edge") > -1) {
+                return;
+            }
+            
             // Write something into an object store.
             let db = new JungleDB('indexTest', 1);
             let st = db.createObjectStore('testStore');

--- a/src/test/generic/Index.spec.js
+++ b/src/test/generic/Index.spec.js
@@ -262,7 +262,6 @@ describe('Index', () => {
 
     it('provides unique indices', (done) => {
         (async function () {
-            debugger;
             // Write something into an object store.
             let db = new JungleDB('indexTest', 1);
             let st = db.createObjectStore('testStore');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5462,9 +5462,9 @@ node-abi@^2.2.0:
   dependencies:
     semver "^5.4.1"
 
-node-lmdb@Venemo/node-lmdb#d9eb604:
+node-lmdb@Venemo/node-lmdb#024bd35:
   version "0.4.13"
-  resolved "https://codeload.github.com/Venemo/node-lmdb/tar.gz/d9eb604791b1ac87724f0f3c78c005c508f012d2"
+  resolved "https://codeload.github.com/Venemo/node-lmdb/tar.gz/024bd35f117bdbe67143723e390114a34a8f55bb"
   dependencies:
     bindings "^1.2.1"
     nan "^2.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,8 +160,8 @@ ansi-colors@^1.0.1:
     ansi-wrap "^0.1.0"
 
 ansi-escapes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
 ansi-gray@^0.1.1:
   version "0.1.1"
@@ -1498,8 +1498,8 @@ camelcase@^2.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 caniuse-lite@^1.0.30000792:
-  version "1.0.30000819"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000819.tgz#aabee5fd15a080febab6ae5d30c9ea15f4c6d4e2"
+  version "1.0.30000820"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000820.tgz#6e36ee75187a2c83d26d6504a1af47cc580324d2"
 
 caseless@~0.11.0:
   version "0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5462,9 +5462,9 @@ node-abi@^2.2.0:
   dependencies:
     semver "^5.4.1"
 
-node-lmdb@Venemo/node-lmdb:
+node-lmdb@Venemo/node-lmdb#d9eb604:
   version "0.4.13"
-  resolved "https://codeload.github.com/Venemo/node-lmdb/tar.gz/1e03ec80c5c9a553ee9867673cb56d3c81821e55"
+  resolved "https://codeload.github.com/Venemo/node-lmdb/tar.gz/d9eb604791b1ac87724f0f3c78c005c508f012d2"
   dependencies:
     bindings "^1.2.1"
     nan "^2.6.2"


### PR DESCRIPTION
This PR introduces the option `unique: boolean` for the creation of indices.
It also adds a note to our readme stating that Edge does not support all types of indices at the time of writing.
Therefore, this PR also excludes certain tests in Edge.