### PR TITLE
Limit queries

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,6 +48,7 @@ const sources = {
         './src/main/generic/utils/LRUMap.js',
         './src/main/generic/utils/ObjectUtils.js',
         './src/main/generic/utils/SetUtils.js',
+        './src/main/generic/utils/SortedList.js',
         './src/main/generic/utils/Synchronizer.js',
         './src/main/generic/utils/EncodedTransaction.js',
         './src/main/generic/utils/GenericValueEncoding.js',

--- a/src/main/backend/indexeddb/JungleDB.js
+++ b/src/main/backend/indexeddb/JungleDB.js
@@ -116,10 +116,11 @@ class JungleDB {
 
     /**
      * Creates a volatile object store (non-persistent).
-     * @param {ICodec} [codec] A codec for the object store.
+     * @param {{codec:?ICodec}} [options] An options object.
      * @returns {ObjectStore}
      */
-    static createVolatileObjectStore(codec=null) {
+    static createVolatileObjectStore(options = {}) {
+        const { codec = null } = options || {};
         return new ObjectStore(new InMemoryBackend('', codec), null);
     }
 

--- a/src/main/backend/leveldb/JungleDB.js
+++ b/src/main/backend/leveldb/JungleDB.js
@@ -177,10 +177,11 @@ class JungleDB {
 
     /**
      * Creates a volatile object store (non-persistent).
-     * @param {ICodec} [codec] A codec for the object store.
+     * @param {{codec:?ICodec}} [options] An options object.
      * @returns {ObjectStore}
      */
-    static createVolatileObjectStore(codec=null) {
+    static createVolatileObjectStore(options = {}) {
+        const { codec = null } = options || {};
         return new ObjectStore(new InMemoryBackend('', codec), null);
     }
 

--- a/src/main/backend/leveldb/LevelDBBackend.js
+++ b/src/main/backend/leveldb/LevelDBBackend.js
@@ -168,15 +168,16 @@ class LevelDBBackend {
      * If the query is of type KeyRange, it returns all objects whose primary keys are within this range.
      * If the query is of type Query, it returns all objects whose primary keys fulfill the query.
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Array.<*>>} A promise of the array of objects relevant to the query.
      */
-    values(query=null) {
+    values(query = null, limit = null) {
         if (query !== null && query instanceof Query) {
-            return query.values(this);
+            return query.values(this, limit);
         }
         return new Promise((resolve, error) => {
             const result = [];
-            this._dbBackend.createReadStream(LevelDBTools.convertKeyRange(query, { 'values': true, 'keys': true }))
+            this._dbBackend.createReadStream(LevelDBTools.convertKeyRange(query, { 'values': true, 'keys': true }, limit))
                 .on('data', data => {
                     try {
                         result.push(this.decode(data.value, data.key));
@@ -202,15 +203,16 @@ class LevelDBBackend {
      * If the query is of type KeyRange, it returns all keys of the object store being within this range.
      * If the query is of type Query, it returns all keys fulfilling the query.
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Set.<string>>} A promise of the set of keys relevant to the query.
      */
-    keys(query=null) {
+    keys(query = null, limit = null) {
         if (query !== null && query instanceof Query) {
-            return query.keys(this);
+            return query.keys(this, limit);
         }
         return new Promise((resolve, error) => {
             const result = new Set();
-            this._dbBackend.createReadStream(LevelDBTools.convertKeyRange(query, { 'values': false, 'keys': true }))
+            this._dbBackend.createReadStream(LevelDBTools.convertKeyRange(query, { 'values': false, 'keys': true }, limit))
                 .on('data', data => {
                     result.add(data);
                 })

--- a/src/main/backend/leveldb/utils/LevelDBTools.js
+++ b/src/main/backend/leveldb/utils/LevelDBTools.js
@@ -3,9 +3,13 @@ class LevelDBTools {
      * Converts our KeyRange object into an options object for LevelDB readstreams.
      * @param {KeyRange} keyRange A KeyRange object.
      * @param {Object} [options] An options object (default empty).
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Object} The options object given extended by the KeyRange.
      */
-    static convertKeyRange(keyRange, options={}) {
+    static convertKeyRange(keyRange, options = {}, limit = null) {
+        if (limit !== null) {
+            options['limit'] = limit;
+        }
         if (!(keyRange instanceof KeyRange)) return options;
         const lowerKey = keyRange.lowerOpen ? 'gt' : 'gte';
         const upperKey = keyRange.upperOpen ? 'lt' : 'lte';

--- a/src/main/backend/lmdb/JungleDB.js
+++ b/src/main/backend/lmdb/JungleDB.js
@@ -67,10 +67,11 @@ class JungleDB {
 
     /**
      * Creates a volatile object store (non-persistent).
-     * @param {ICodec} [codec] A codec for the object store.
+     * @param {{codec:?ICodec}} [options] An options object.
      * @returns {ObjectStore}
      */
-    static createVolatileObjectStore(codec=null) {
+    static createVolatileObjectStore(options = {}) {
+        const { codec = null } = options || {};
         return new ObjectStore(new InMemoryBackend('', codec), null);
     }
 

--- a/src/main/backend/lmdb/LMDBBackend.js
+++ b/src/main/backend/lmdb/LMDBBackend.js
@@ -98,16 +98,19 @@ class LMDBBackend extends LMDBBaseBackend {
      * If the query is of type KeyRange, it returns all objects whose primary keys are within this range.
      * If the query is of type Query, it returns all objects whose primary keys fulfill the query.
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Array.<*>>} A promise of the array of objects relevant to the query.
      */
-    async values(query=null) {
+    async values(query = null, limit = null) {
         if (query !== null && query instanceof Query) {
-            return query.values(this);
+            return query.values(this, limit);
         }
 
         let result = [];
         this._readStream((value, key) => {
+            if (limit !== null && result.length >= limit) return false;
             result.push(value);
+            return true;
         }, true, query);
         return result;
     }
@@ -118,15 +121,18 @@ class LMDBBackend extends LMDBBaseBackend {
      * If the query is of type KeyRange, it returns all keys of the object store being within this range.
      * If the query is of type Query, it returns all keys fulfilling the query.
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Set.<string>>} A promise of the set of keys relevant to the query.
      */
-    async keys(query = null) {
+    async keys(query = null, limit = null) {
         if (query !== null && query instanceof Query) {
-            return query.keys(this);
+            return query.keys(this, limit);
         }
         let resultSet = new Set();
         this._readStream((value, key) => {
+            if (limit !== null && resultSet.size >= limit) return false;
             resultSet.add(key);
+            return true;
         }, true, query, true);
         return resultSet;
     }

--- a/src/main/backend/lmdb/PersistentIndex.js
+++ b/src/main/backend/lmdb/PersistentIndex.js
@@ -181,10 +181,11 @@ class PersistentIndex extends LMDBBaseBackend {
      * If the optional query is not given, it returns all objects in the index.
      * If the query is of type KeyRange, it returns all objects whose secondary keys are within this range.
      * @param {KeyRange} [query] Optional query to check secondary keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Array.<*>>} A promise of the array of objects relevant to the query.
      */
-    async values(query=null) {
-        const results = this._getValues(query);
+    async values(query = null, limit = null) {
+        const results = this._getValues(query, limit);
         return this._retrieveValues(results);
     }
 
@@ -193,10 +194,11 @@ class PersistentIndex extends LMDBBaseBackend {
      * If the optional query is not given, it returns all primary keys in the index.
      * If the query is of type KeyRange, it returns all primary keys for which the secondary key is within this range.
      * @param {KeyRange} [query] Optional query to check the secondary keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Set.<string>>} A promise of the set of primary keys relevant to the query.
      */
-    async keys(query=null) {
-        const results = this._getValues(query);
+    async keys(query = null, limit = null) {
+        const results = this._getValues(query, limit);
         return Set.from(results);
     }
 
@@ -327,13 +329,16 @@ class PersistentIndex extends LMDBBaseBackend {
 
     /**
      * @param {KeyRange} [query]
+     * @param {number} [limit]
      * @return {Array.<string>}
      * @private
      */
-    _getValues(query) {
+    _getValues(query, limit = null) {
         let result = [];
         this._readStream((value, key) => {
+            if (limit !== null && result.length >= limit) return false;
             result.push(value);
+            return true;
         }, true, query);
         return result;
     }

--- a/src/main/generic/CachedBackend.js
+++ b/src/main/generic/CachedBackend.js
@@ -153,10 +153,11 @@ class CachedBackend {
      * If the query is of type KeyRange, it returns all keys of the object store being within this range.
      * If the query is of type Query, it returns all keys fulfilling the query.
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Set.<string>>} A promise of the set of keys relevant to the query.
      */
-    keys(query=null) {
-        return this._backend.keys(query);
+    keys(query = null, limit = null) {
+        return this._backend.keys(query, limit);
     }
 
     /**
@@ -165,10 +166,11 @@ class CachedBackend {
      * If the query is of type KeyRange, it returns all objects whose primary keys are within this range.
      * If the query is of type Query, it returns all objects whose primary keys fulfill the query.
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Array.<*>>} A promise of the array of objects relevant to the query.
      */
-    values(query=null) {
-        return this._backend.values(query);
+    values(query = null, limit = null) {
+        return this._backend.values(query, limit);
     }
 
     /**

--- a/src/main/generic/InMemoryBackend.js
+++ b/src/main/generic/InMemoryBackend.js
@@ -61,14 +61,15 @@ class InMemoryBackend {
 
     /**
      * @param {Query|KeyRange} [query]
+     * @param {number} [limit]
      * @returns {Promise.<Array.<*>>}
      */
-    async values(query=null) {
+    async values(query = null, limit = null) {
         if (query !== null && query instanceof Query) {
-            return query.values(this);
+            return query.values(this, limit);
         }
         const values = [];
-        for (const key of await this.keys(query)) {
+        for (const key of await this.keys(query, limit)) {
             values.push(await this.get(key));
         }
         return Promise.resolve(values);
@@ -76,13 +77,14 @@ class InMemoryBackend {
 
     /**
      * @param {Query|KeyRange} [query]
+     * @param {number} [limit]
      * @returns {Promise.<Set.<string>>}
      */
-    keys(query=null) {
+    keys(query = null, limit = null) {
         if (query !== null && query instanceof Query) {
-            return query.keys(this);
+            return query.keys(this, limit);
         }
-        return this._primaryIndex.keys(query);
+        return this._primaryIndex.keys(query, limit);
     }
 
     /**

--- a/src/main/generic/ObjectStore.js
+++ b/src/main/generic/ObjectStore.js
@@ -152,14 +152,15 @@ class ObjectStore {
      * If the query is of type KeyRange, it returns all keys of the object store being within this range.
      * If the query is of type Query, it returns all keys fulfilling the query.
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Set.<string>>} A promise of the set of keys relevant to the query.
      */
-    keys(query=null) {
+    keys(query = null, limit = null) {
         if (!this._backend.connected) throw new Error('JungleDB is not connected');
         if (query !== null && query instanceof Query) {
-            return query.keys(this._currentState);
+            return query.keys(this._currentState, limit);
         }
-        return this._currentState.keys(query);
+        return this._currentState.keys(query, limit);
     }
 
     /**
@@ -168,14 +169,15 @@ class ObjectStore {
      * If the query is of type KeyRange, it returns all objects whose primary keys are within this range.
      * If the query is of type Query, it returns all objects whose primary keys fulfill the query.
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Array.<*>>} A promise of the array of objects relevant to the query.
      */
-    values(query=null) {
+    values(query = null, limit = null) {
         if (!this._backend.connected) throw new Error('JungleDB is not connected');
         if (query !== null && query instanceof Query) {
-            return query.values(this._currentState);
+            return query.values(this._currentState, limit);
         }
-        return this._currentState.values(query);
+        return this._currentState.values(query, limit);
     }
 
     /**

--- a/src/main/generic/interfaces/IIndex.js
+++ b/src/main/generic/interfaces/IIndex.js
@@ -49,9 +49,10 @@ class IIndex {
      * If the query is of type KeyRange, it returns all primary keys for which the secondary key is within this range.
      * @abstract
      * @param {KeyRange} [query] Optional query to check the secondary keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Set.<string>>} A promise of the set of primary keys relevant to the query.
      */
-    async keys(query=null) {} // eslint-disable-line no-unused-vars
+    async keys(query = null, limit = null) {} // eslint-disable-line no-unused-vars
 
     /**
      * Returns a promise of an array of objects whose secondary keys fulfill the given query.
@@ -59,9 +60,10 @@ class IIndex {
      * If the query is of type KeyRange, it returns all objects whose secondary keys are within this range.
      * @abstract
      * @param {KeyRange} [query] Optional query to check secondary keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Array.<*>>} A promise of the array of objects relevant to the query.
      */
-    async values(query=null) {} // eslint-disable-line no-unused-vars
+    async values(query = null, limit = null) {} // eslint-disable-line no-unused-vars
 
     /**
      * Returns a promise of an array of objects whose secondary key is maximal for the given range.

--- a/src/main/generic/interfaces/IJungleDB.js
+++ b/src/main/generic/interfaces/IJungleDB.js
@@ -60,10 +60,10 @@ class IJungleDB {
     /**
      * Creates a volatile object store (non-persistent).
      * @abstract
-     * @param {function(obj:*):*} [codec] A codec for the object store.
-     * @returns {IObjectStore}
+     * @param {{codec:?ICodec}} [options] An options object.
+     * @returns {ObjectStore}
      */
-    static createVolatileObjectStore(codec=null) {} // eslint-disable-line no-unused-vars
+    static createVolatileObjectStore(options = {}) {} // eslint-disable-line no-unused-vars
 
     /**
      * Is used to commit multiple transactions atomically.

--- a/src/main/generic/interfaces/IReadableObjectStore.js
+++ b/src/main/generic/interfaces/IReadableObjectStore.js
@@ -47,9 +47,10 @@ class IReadableObjectStore {
      * If the query is of type Query, it returns all keys fulfilling the query.
      * @abstract
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Set.<string>>} A promise of the set of keys relevant to the query.
      */
-    async keys(query=null) {} // eslint-disable-line no-unused-vars
+    async keys(query = null, limit = null) {} // eslint-disable-line no-unused-vars
 
     /**
      * Returns a promise of an array of objects whose primary keys fulfill the given query.
@@ -58,9 +59,10 @@ class IReadableObjectStore {
      * If the query is of type Query, it returns all objects whose primary keys fulfill the query.
      * @abstract
      * @param {Query|KeyRange} [query] Optional query to check keys against.
+     * @param {number} [limit] Limits the number of results if given.
      * @returns {Promise.<Array.<*>>} A promise of the array of objects relevant to the query.
      */
-    async values(query=null) {} // eslint-disable-line no-unused-vars
+    async values(query = null, limit = null) {} // eslint-disable-line no-unused-vars
 
     /**
      * Iterates over the keys in a given range and direction.

--- a/src/main/generic/utils/SetUtils.js
+++ b/src/main/generic/utils/SetUtils.js
@@ -63,6 +63,26 @@ Set.prototype.equals = function(setB) {
 };
 
 /**
+ * Limits the number of items in the set.
+ * @param {number} [limit] Limits the number of results if given.
+ * @returns {Set}
+ */
+Set.prototype.limit = function(limit = null) {
+    if (limit === null) return this;
+
+    const limitedResults = new Set();
+    let count = 0;
+    for (const val of this) {
+        // Limit
+        if (limit !== null && count >= limit) break;
+
+        limitedResults.add(val);
+        count++;
+    }
+    return limitedResults;
+};
+
+/**
  * Creates a Set from single values and iterables.
  * If arg is not iterable, it creates a new Set with arg as its single member.
  * If arg is iterable, it iterates over arg and puts all items into the Set.

--- a/src/main/generic/utils/SortedList.js
+++ b/src/main/generic/utils/SortedList.js
@@ -1,0 +1,112 @@
+class SortedList {
+    constructor(sortedList = [], compare) {
+        this._list = sortedList;
+        this._compare = compare || SortedList._compare;
+    }
+
+    static _compare(a, b) {
+        return a.compare ? a.compare(b) : (a > b ? 1 : (a < b ? -1 : 0));
+    }
+
+    indexOf(o) {
+        let a = 0, b = this._list.length - 1;
+        let currentIndex = null;
+        let currentElement = null;
+
+        while (a <= b) {
+            currentIndex = Math.round((a + b) / 2);
+            currentElement = this._list[currentIndex];
+
+            if (this._compare(currentElement, o) < 0) {
+                a = currentIndex + 1;
+            }
+            else if (this._compare(currentElement, o) > 0) {
+                b = currentIndex - 1;
+            }
+            else {
+                return currentIndex;
+            }
+        }
+
+        return -1;
+    }
+
+    _insertionIndex(o) {
+        let a = 0, b = this._list.length - 1;
+        let currentIndex = null;
+        let currentElement = null;
+
+        while (a <= b) {
+            currentIndex = Math.round((a + b) / 2);
+            currentElement = this._list[currentIndex];
+
+            if (this._compare(currentElement, o) < 0) {
+                a = currentIndex + 1;
+            }
+            else if (this._compare(currentElement, o) > 0) {
+                b = currentIndex - 1;
+            }
+            else {
+                break;
+            }
+        }
+
+        return a;
+    }
+
+    add(value) {
+        this._list.splice(this._insertionIndex(value), 0, value);
+    }
+
+    has(value) {
+        return this.indexOf(value) >= 0;
+    }
+
+    shift() {
+        return this._list.shift();
+    }
+
+    pop() {
+        return this._list.pop();
+    }
+
+    peekFirst() {
+        return this._list[0];
+    }
+
+    peekLast() {
+        return this._list[this._list.length - 1];
+    }
+
+    remove(value) {
+        const index = this.indexOf(value);
+        if (index > -1) {
+            this._list.splice(index, 1);
+        }
+    }
+
+    clear() {
+        this._list = [];
+    }
+
+    values() {
+        return this._list;
+    }
+
+    /**
+     * @returns {Iterator.<V|*>}
+     */
+    [Symbol.iterator]() {
+        return this._list[Symbol.iterator]();
+    }
+
+    copy() {
+        return new SortedList(this._list.slice(), this._compare);
+    }
+
+    /** @type {number} */
+    get length() {
+        return this._list.length;
+    }
+}
+Class.register(SortedList);

--- a/src/test/generic/ObjectStore.spec.js
+++ b/src/test/generic/ObjectStore.spec.js
@@ -287,5 +287,48 @@ describe('ObjectStore', () => {
                 await runner.destroy();
             })().then(done, done.fail);
         });
+
+        it(`returns ordered results (${runner.type})`, (done) => {
+            (async function () {
+                // Write something into an object store.
+                let st = await runner.init();
+                await st.truncate();
+
+                await st.put('test1', {'v': 1, 'a': 123});
+                await st.put('test3', {'v': 3, 'a': 123});
+                await st.put('test2', {'v': 2, 'a': 123});
+                await st.put('test0', {'v': 0, 'a': 124});
+
+                let keys = await st.keys();
+                let i = 0;
+                for (const key of keys) {
+                    expect(key).toBe(`test${i}`);
+                    i++;
+                }
+
+                let values = await st.values();
+                i = 0;
+                for (const value of values) {
+                    expect(value.v).toBe(i);
+                    i++;
+                }
+
+                keys = await st.keys(KeyRange.lowerBound('test2'));
+                i = 2;
+                for (const key of keys) {
+                    expect(key).toBe(`test${i}`);
+                    i++;
+                }
+
+                values = await st.values(KeyRange.upperBound('test1'));
+                i = 0;
+                for (const value of values) {
+                    expect(value.v).toBe(i);
+                    i++;
+                }
+
+                await runner.destroy();
+            })().then(done, done.fail);
+        });
     });
 });

--- a/src/test/generic/RawRetrieval.spec.js
+++ b/src/test/generic/RawRetrieval.spec.js
@@ -7,7 +7,7 @@ describe('RawRetrieval', () => {
 
     const backends = [
         TestRunner.nativeRunner('test', 1, jdb => jdb.createObjectStore('testStore', {codec: TestCodec.instance, enableLruCache: false}), fill, 'without-cache'),
-        TestRunner.volatileRunner(() => JungleDB.createVolatileObjectStore(TestCodec.instance), fill),
+        TestRunner.volatileRunner(() => JungleDB.createVolatileObjectStore({codec: TestCodec.instance}), fill),
         TestRunner.nativeRunner('test', 1, jdb => jdb.createObjectStore('testStore', {codec: TestCodec.instance, enableLruCache: true}), fill, 'with-value-cache'),
         TestRunner.nativeRunner('test', 1, jdb => jdb.createObjectStore('testStore', {codec: TestCodec.instance, enableLruCache: true, rawLruCacheSize: 100}), fill, 'with-raw-cache')
     ];

--- a/src/test/generic/utils/SortedList.spec.js
+++ b/src/test/generic/utils/SortedList.spec.js
@@ -1,0 +1,117 @@
+describe('SortedList', () => {
+    it('correctly inserts elements', () => {
+        const s = new SortedList();
+
+        s.add(4);
+        expect(s.values()).toEqual([4]);
+
+        s.add(2);
+        expect(s.values()).toEqual([2,4]);
+
+        s.add(3);
+        expect(s.values()).toEqual([2,3,4]);
+
+        s.add(8);
+        expect(s.values()).toEqual([2,3,4,8]);
+
+        s.add(6);
+        expect(s.values()).toEqual([2,3,4,6,8]);
+
+        s.add(5);
+        expect(s.values()).toEqual([2,3,4,5,6,8]);
+
+        s.add(4);
+        expect(s.values()).toEqual([2,3,4,4,5,6,8]);
+    });
+
+    it('can clear itself', () => {
+        const s = new SortedList();
+
+        s.add(3);
+        s.add(1);
+        s.add(2);
+
+        expect(s.length).toBe(3);
+        s.clear();
+        expect(s.length).toBe(0);
+    });
+
+    it('can indexOf', () => {
+        const s = new SortedList();
+
+        s.add(3);
+        s.add(1);
+
+        expect(s.indexOf(3)).toBe(1);
+        expect(s.indexOf(1)).toBe(0);
+        expect(s.indexOf(2)).toBe(-1);
+    });
+
+    it('can has', () => {
+        const s = new SortedList();
+
+        s.add(3);
+        s.add(1);
+
+        expect(s.has(3)).toBe(true);
+        expect(s.has(1)).toBe(true);
+        expect(s.has(2)).toBe(false);
+    });
+
+    it('can shift', () => {
+        const s = new SortedList();
+
+        s.add(3);
+        s.add(1);
+        s.add(2);
+
+        expect(s.length).toBe(3);
+        expect(s.values()).toEqual([1,2,3]);
+        expect(s.shift()).toBe(1);
+        expect(s.length).toBe(2);
+        expect(s.values()).toEqual([2,3]);
+    });
+
+    it('can pop', () => {
+        const s = new SortedList();
+
+        s.add(3);
+        s.add(1);
+        s.add(2);
+
+        expect(s.length).toBe(3);
+        expect(s.values()).toEqual([1,2,3]);
+        expect(s.pop()).toBe(3);
+        expect(s.length).toBe(2);
+        expect(s.values()).toEqual([1,2]);
+    });
+
+    it('can remove elements', () => {
+        const s = new SortedList([1, 2, 3]);
+
+        expect(s.length).toBe(3);
+        expect(s.values()).toEqual([1,2,3]);
+        s.remove(2);
+        s.remove(5);
+        expect(s.length).toBe(2);
+        expect(s.values()).toEqual([1,3]);
+    });
+
+    it('can be copied', () => {
+        const s1 = new SortedList([1, 2, 3]);
+        const s2 = s1.copy();
+
+        expect(s1.length).toBe(3);
+        expect(s1.values()).toEqual([1,2,3]);
+        expect(s2.length).toBe(3);
+        expect(s2.values()).toEqual([1,2,3]);
+
+        s1.remove(1);
+        s2.add(4);
+
+        expect(s1.length).toBe(2);
+        expect(s1.values()).toEqual([2,3]);
+        expect(s2.length).toBe(4);
+        expect(s2.values()).toEqual([1,2,3,4]);
+    });
+});


### PR DESCRIPTION
Allow to limit the number of results returned by a query.
All query results (no matter whether returned as `Set` or `Array`) are always sorted by the corresponding key.
That means that queries based on the primary key are always ordered by primary key.
Queries based on secondary keys are ordered by secondary key (and for equal secondary keys by primary key).

For `Set` return values, this order is preserved, since JavaScript sets are sorted by insertion order.